### PR TITLE
ci: set all Dependabot schedules to daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,13 +13,13 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "build(deps)"
 
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
-      interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "build(deps)"


### PR DESCRIPTION
# Description

Change gomod and npm Dependabot schedules from weekly to daily to match github-actions. This also triggers Dependabot to rescan immediately, which will recreate the closed PRs (#28, #30, #31) with the new `build(deps):` prefix.

## Test Plan

- [ ] Dependabot creates new PRs with `build(deps):` prefix after merge