### PR TITLE
ci: add Claude Code PR review and Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,51 @@
+# Copilot Review Instructions
+
+This is a Go project (`github.com/sensiblebit/certkit`) targeting Go 1.25+. Review
+all changes against the rules in `CLAUDE.md` at the repository root. Flag violations
+by rule ID (e.g., ERR-1, CS-2).
+
+## Critical rules (block merge if violated)
+
+- **ERR-1** Every error must be wrapped with `%w` and context: `fmt.Errorf("loading JKS: %w", err)`.
+- **ERR-4** Error strings are lowercase, no trailing punctuation. Acronyms (JKS, PEM, SKI) are exempt.
+- **ERR-5** Never silently ignore errors. Loop `continue` requires `slog.Debug`.
+- **ERR-6** Fail fast — return errors immediately, don't accumulate.
+- **CS-1** Code must pass `gofmt`, `go vet`, `goimports`.
+- **CS-2** No name stutter: `package kv; type Store` not `KVStore`.
+- **CS-5** Functions with >2 args must use an input struct. `context.Context` stays outside.
+- **T-1** All tests must pass. No disabled tests.
+- **T-5** Tests use stdlib `testing` only — no testify, gomock, or third-party test frameworks.
+- **T-6** Every encode/decode path needs a round-trip test.
+- **SEC-2** Never log secrets (private keys, passwords).
+- **CLI-1** Stdout is for data, stderr for diagnostics.
+- **CLI-2** Never write files without explicit user consent (`-o` flag or `--bundle-path`).
+- **GIT-8** Commit messages must follow Conventional Commits: `type: description` or `type(scope): description`.
+- **CL-1** Every commit changing behavior must update `CHANGELOG.md` under `## [Unreleased]`.
+
+## Style checks
+
+- Two import groups: stdlib, then third-party. Alphabetical within each group.
+- Exported functions require godoc comments. No exceptions.
+- Error variables: `errFoo` (unexported), `ErrFoo` (exported).
+- Test helpers must call `t.Helper()`.
+- Prefer `certificate` over `cert` in function names (variables are fine abbreviated).
+- Use `errors.Is`/`errors.As` for error control flow — never string match.
+- Use `log/slog` exclusively. Never `log` or `fmt.Print` for diagnostics.
+- `context.Context` is always the first parameter; never stored in structs.
+- The sender closes channels; receivers never close.
+
+## Testing standards
+
+- Table-driven tests with descriptive subtest names.
+- One assertion per logical check.
+- Test names describe the scenario: `TestDecodeJKS_DifferentKeyPassword` not `TestDecodeJKS2`.
+- Mark safe tests with `t.Parallel()`.
+- Tests generate certificates dynamically — no committed fixture files.
+- Cover edge cases: wrong/missing passwords, empty containers, expired certs, corrupted input.
+
+## Architecture
+
+- `MemStore` is the primary runtime store. SQLite is only for `--save-db`/`--load-db`.
+- Root package is the public library API. CLI is in `cmd/certkit/`. Business logic in `internal/certstore/`.
+- Composition over inheritance. Interfaces near consumers.
+- No premature abstractions. Consistency with existing patterns trumps personal preference.

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,31 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+jobs:
+  claude-review:
+    if: |
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: read
+      id-token: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code Review
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
+          plugins: 'code-review@claude-code-plugins'
+          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,45 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (
+        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+        (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      ) && (
+        github.event.sender.login == github.repository_owner ||
+        github.event.comment.author_association == 'OWNER' ||
+        github.event.comment.author_association == 'MEMBER' ||
+        github.event.comment.author_association == 'COLLABORATOR'
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add pull request template with summary, test plan, and checklist
 - Add `--fix` suggestion to `checks.py` goimports failure output
 - Add `require_tool()` guard in `checks.py` for `go`, `gh` — gives clear errors when tools are missing locally
+- Add Claude Code automatic PR review and `@claude` mention workflows
+- Add Copilot review instructions (`.github/copilot-instructions.md`) with project coding standards
 
 ### Fixed
 


### PR DESCRIPTION
# Description

Add automated code review via Claude Code and review guidance for Copilot.

### Claude Code workflows

- **claude-code-review.yml** — Automatic review on every non-draft, non-fork PR using the `code-review` plugin
- **claude.yml** — `@claude` mention handler for PRs and issues

### Access control

- Auto-review skips fork PRs (`head.repo.full_name == github.repository`)
- `@claude` mentions restricted to OWNER, MEMBER, or COLLABORATOR — random contributors cannot trigger it

### Copilot instructions

- `.github/copilot-instructions.md` distills the strict rules from `CLAUDE.md` into review-focused guidance, referencing rule IDs (ERR-1, CS-2, etc.)

## Test Plan

- [ ] Claude Code Review triggers on this PR
- [ ] `@claude` mention works for repo owner
- [ ] Fork PRs do not trigger auto-review