### PR TITLE
ci: add --comment flag to code-review plugin prompt

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -28,5 +28,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
-          prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
-          show_full_output: true
+          prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
# Description

Fix Claude Code Review not posting comments on PRs. The `code-review` plugin requires the `--comment` flag to post findings to the PR — without it, output only goes to terminal.

Root cause: the plugin README states `/code-review [--comment]` where `--comment` posts the review as a PR comment. Our prompt was missing this flag.

Also removes the temporary `show_full_output: true` debug flag added while investigating.

## Test Plan

- [ ] Merge this PR, then retrigger review on PR #39 (which has intentional SEC-2 and ERR-5 violations)
- [ ] Verify Claude posts a review comment on the PR