### PR TITLE
ci: refactor Claude review to reusable org-wide workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,50 +4,17 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions:
+  contents: read
+  pull-requests: write
+  issues: read
+  id-token: write
+
 jobs:
   claude-review:
     if: |
       github.event.pull_request.draft == false &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-      issues: read
-      id-token: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 1
-
-      - name: Minimize previous Claude review comments
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh pr view ${{ github.event.pull_request.number }} \
-            --json comments \
-            --jq '.comments[] | select(.author.login == "claude") | .id' \
-          | while read -r node_id; do
-            gh api graphql -f query='
-              mutation {
-                minimizeComment(input: {subjectId: "'"$node_id"'", classifier: OUTDATED}) {
-                  minimizedComment { isMinimized }
-                }
-              }'
-          done
-
-      - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
-        with:
-          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
-          plugins: 'code-review@claude-code-plugins'
-          prompt: |
-            /code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}
-
-            IMPORTANT: You MUST always post a PR comment, even if no issues are found.
-            Do NOT skip the review for any reason — never treat a PR as "trivial" or
-            "obviously correct." Always run the full review pipeline and post a comment
-            with the results. If no issues are found, post the "No issues found" summary.
+    uses: sensiblebit/.github/.github/workflows/claude-code-review.yml@main
+    secrets:
+      CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace inline Claude review workflow with a thin caller to a reusable workflow in `sensiblebit/.github`
- Any repo in the org can get Claude reviews with a 14-line caller + the `CLAUDE_CODE_OAUTH_TOKEN` secret
- All review logic (skip detection, comment minimization, always-comment enforcement) is centralized

## Test plan

- [x] Workflow parses correctly (no `startup_failure`)
- [x] Skip detection works when workflow file is modified
- [ ] Normal review works on a PR that doesn't touch the workflow file (testable after merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)