### PR TITLE
ci: add go fix to pre-commit hooks and CI checks

### DIFF
--- a/.claude/rules/commits-and-prs.md
+++ b/.claude/rules/commits-and-prs.md
@@ -1,11 +1,5 @@
 ---
-paths:
-  - ".github/**"
-  - "CHANGELOG.md"
-  - "*"
 description: Git conventions for commits, branches, and PRs
-globs:
-  - "**"
 ---
 
 # Commit & PR Conventions

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,11 +8,12 @@ repos:
         args: [--branch, main]
 
   - repo: https://github.com/sensiblebit/.github
-    rev: "27cc26b"
+    rev: "0b4c9df"
     hooks:
       - id: branch-name
       - id: commit-message
       - id: goimports
+      - id: go-fix
       - id: wasm
       - id: go-vet
       - id: go-build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,7 +47,7 @@ Detailed file-by-file descriptions: `.claude/docs/architecture.md`
 
 ## 4 — Code Style
 
-- **CS-1 (MUST)** Enforce `gofmt`, `go vet`, `goimports` before committing.
+- **CS-1 (MUST)** Enforce `gofmt`, `go fix`, `go vet`, `goimports` before committing.
 - **CS-2 (MUST)** Avoid stutter in names: `package kv; type Store` (not `KVStore` in `kv`).
 - **CS-3 (SHOULD)** Small interfaces near consumers; prefer composition over inheritance.
 - **CS-4 (SHOULD)** Avoid reflection on hot paths; prefer generics when it clarifies and speeds.
@@ -123,6 +123,7 @@ Target the latest stable Go release. Use modern stdlib features freely: `slices`
 ```sh
 go test ./...          # Run all tests
 go build ./...         # Verify compilation
+go fix ./...           # Apply modernizer fixes
 go vet ./...           # Static analysis
 golangci-lint run      # Lint (errcheck, unused, staticcheck, etc.)
 ```
@@ -316,7 +317,7 @@ Every PR runs 10 parallel checks (`.github/workflows/ci.yml`):
 |---|---|
 | PR Title | Conventional Commits format |
 | PR Conventions | Branch name, commit messages, verified commits |
-| Go Checks | `go build`, `go vet`, goimports |
+| Go Checks | `go build`, `go fix`, `go vet`, goimports |
 | Go Test | `go test -race -count=1 ./...` |
 | Lint (golangci-lint) | errcheck, staticcheck, unused, etc. |
 | Vulnerability Check | `govulncheck ./...` |
@@ -340,16 +341,17 @@ pre-commit install --hook-type commit-msg
 pre-commit run --all-files  # Manual run against all files
 ```
 
-Configured hooks: `no-commit-to-branch`, `branch-name`, `commit-message` (commit-msg stage), `goimports`, `go vet`, `go build`, `go test`, `wasm`, `prettier`, `vitest`, `wrangler build`, `markdownlint`.
+Configured hooks: `no-commit-to-branch`, `branch-name`, `commit-message` (commit-msg stage), `goimports`, `go-fix`, `go vet`, `go build`, `go test`, `wasm`, `prettier`, `vitest`, `wrangler build`, `markdownlint`.
 
 ### Tooling gates
 
-- **G-1 (MUST)** `go vet ./...` passes.
-- **G-2 (MUST)** `go test -race ./...` passes.
-- **G-3 (MUST)** `golangci-lint run` passes with default linters (errcheck, staticcheck, unused, etc.). No `.golangci.yml` config — uses golangci-lint defaults.
-- **G-4 (MUST)** `GOOS=js GOARCH=wasm go vet ./cmd/wasm/` and `go build` pass.
-- **G-5 (MUST)** `cd web && npm test` passes (vitest).
-- **G-6 (MUST)** `cd web && wrangler pages functions build` compiles (local only, no credentials).
+- **G-1 (MUST)** `go fix ./...` leaves no pending changes.
+- **G-2 (MUST)** `go vet ./...` passes.
+- **G-3 (MUST)** `go test -race ./...` passes.
+- **G-4 (MUST)** `golangci-lint run` passes with default linters (errcheck, staticcheck, unused, etc.). No `.golangci.yml` config — uses golangci-lint defaults.
+- **G-5 (MUST)** `GOOS=js GOARCH=wasm go vet ./cmd/wasm/` and `go build` pass.
+- **G-6 (MUST)** `cd web && npm test` passes (vitest).
+- **G-7 (MUST)** `cd web && wrangler pages functions build` compiles (local only, no credentials).
 
 ---
 


### PR DESCRIPTION
## Summary

- Add `go fix` pre-commit hook and CI step (via org `sensiblebit/.github`) to enforce modernizer fixes automatically
- Update CLAUDE.md: CS-1, CI checks table, pre-commit hook list, tooling gates (G-1 through G-7)
- Fix invalid frontmatter in `.claude/rules/commits-and-prs.md` (remove unsupported `globs` and stale `paths` keys)

## Org repo changes

The org-level changes (`sensiblebit/.github@0b4c9df`) are already on main:
- `.pre-commit-hooks.yaml` — new `go-fix` hook
- `.github/workflows/go-ci.yml` — new `Fix` step (runs `go fix ./...`, fails if changes pending)

## Test plan

- [x] `pre-commit run go-fix --all-files` passes locally
- [ ] CI validates the new hook rev resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)