### PR TITLE
chore: prepare v0.8.0 release and enable winget workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,6 @@ jobs:
           HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
 
   winget:
-    if: false # Enable after initial manual winget-pkgs submission
     needs: release
     runs-on: windows-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-02-22
+
 ### Added
 
 - Add `ValidateAIAURL` to block SSRF via non-HTTP schemes and literal private/loopback IP addresses in AIA URLs ([#56])
@@ -528,7 +530,8 @@ Initial release.
 - PKCS#12, PKCS#7, and JKS encode/decode support
 - Homebrew distribution via GoReleaser
 
-[Unreleased]: https://github.com/sensiblebit/certkit/compare/v0.7.7...HEAD
+[Unreleased]: https://github.com/sensiblebit/certkit/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/sensiblebit/certkit/compare/v0.7.7...v0.8.0
 [0.7.7]: https://github.com/sensiblebit/certkit/compare/v0.7.6...v0.7.7
 [0.7.6]: https://github.com/sensiblebit/certkit/compare/v0.7.5...v0.7.6
 [0.7.5]: https://github.com/sensiblebit/certkit/compare/v0.7.4...v0.7.5


### PR DESCRIPTION
## Summary

- Rename `[Unreleased]` to `[0.8.0] - 2026-02-22` with fresh empty `[Unreleased]` section
- Update comparison link definitions at bottom of CHANGELOG.md
- Enable winget job in release workflow (remove `if: false` gate)

**Note:** Tag `v0.8.0` will be pushed separately to trigger the release.

## Test plan

- [x] markdownlint passes (no duplicate headings, valid links)
- [x] All pre-commit hooks pass
- [ ] After merge, push `v0.8.0` tag to trigger GoReleaser + winget

🤖 Generated with [Claude Code](https://claude.com/claude-code)