### PR TITLE
feat(web): add Inspect tab, certkitInspect WASM, and FormatDN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add Scan/Inspect page-level tabs to web UI — Inspect tab provides stateless inspection of certificates, keys, and CSRs with detailed metadata cards
+- Add `certkitInspect` WASM function for stateless inspection of certificates, keys, and CSRs without accumulating into the global store
+- Add `InspectData` function to `internal` package for inspecting in-memory bytes (used by both CLI and WASM)
+- Add `FormatDN` function to render `emailAddress` OID as a human-readable label instead of raw hex in distinguished names
+- Add `FormatEKUs` function (moved from WASM-only code to shared root package) for consistent EKU formatting across CLI and WASM
+- Add EKU and email SAN display to `inspect` command output for certificates and CSRs
+- Add AIA resolution to `inspect` command and WASM `certkitInspect` — automatically fetches missing intermediate certificates before trust annotation
 - Add `certkitValidateCert` WASM function for browser-based certificate validation ([`392878a`])
 - Add concurrent AIA resolution — fetches up to `Concurrency` URLs in parallel per depth round (default 20, WASM uses 50) ([`392878a`])
 - Add `serial` field to WASM `getState()` certificate data — hex-encoded serial number ([`392878a`])

--- a/certkit_test.go
+++ b/certkit_test.go
@@ -1772,3 +1772,69 @@ func TestAlgorithmName(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatDN(t *testing.T) {
+	t.Parallel()
+
+	// emailAddress OID (1.2.840.113549.1.9.1)
+	oidEmail := asn1.ObjectIdentifier{1, 2, 840, 113549, 1, 9, 1}
+
+	tests := []struct {
+		name string
+		dn   pkix.Name
+		want string
+	}{
+		{
+			name: "standard OIDs only delegates to String",
+			dn: pkix.Name{
+				CommonName:   "example.com",
+				Organization: []string{"Example Inc."},
+				Country:      []string{"US"},
+			},
+			want: "CN=example.com,O=Example Inc.,C=US",
+		},
+		{
+			name: "emailAddress rendered with label",
+			dn: pkix.Name{
+				CommonName:   "acme.com",
+				Organization: []string{"Acme Corp"},
+				Country:      []string{"US"},
+				// Names simulates what the ASN.1 parser populates.
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: asn1.ObjectIdentifier{2, 5, 4, 6}, Value: "US"},
+					{Type: asn1.ObjectIdentifier{2, 5, 4, 10}, Value: "Acme Corp"},
+					{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "acme.com"},
+					{Type: oidEmail, Value: "admin@acme.com"},
+				},
+			},
+			// Go's String() puts standard OIDs first (RFC 4514 reverse),
+			// then appends extra OIDs at the end.
+			want: "CN=acme.com,O=Acme Corp,C=US,emailAddress=admin@acme.com",
+		},
+		{
+			name: "emailAddress with special characters escaped",
+			dn: pkix.Name{
+				CommonName: "example.com",
+				Names: []pkix.AttributeTypeAndValue{
+					{Type: asn1.ObjectIdentifier{2, 5, 4, 3}, Value: "example.com"},
+					{Type: oidEmail, Value: "user+tag@example.com"},
+				},
+			},
+			want: "CN=example.com,emailAddress=user\\+tag@example.com",
+		},
+		{
+			name: "empty name",
+			dn:   pkix.Name{},
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := FormatDN(tt.dn)
+			if got != tt.want {
+				t.Errorf("FormatDN() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/certkit/inspect.go
+++ b/cmd/certkit/inspect.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"log/slog"
 	"slices"
 
 	"github.com/sensiblebit/certkit/internal"
@@ -36,6 +37,12 @@ func runInspect(cmd *cobra.Command, args []string) error {
 	results, err := internal.InspectFile(args[0], passwords)
 	if err != nil {
 		return fmt.Errorf("inspecting %s: %w", args[0], err)
+	}
+
+	// Resolve missing intermediates via AIA before trust annotation.
+	results, aiaWarnings := internal.ResolveInspectAIA(cmd.Context(), results, httpAIAFetcher)
+	for _, w := range aiaWarnings {
+		slog.Warn("AIA resolution", "warning", w)
 	}
 
 	if err := internal.AnnotateInspectTrust(results); err != nil {

--- a/cmd/wasm/inspect.go
+++ b/cmd/wasm/inspect.go
@@ -1,0 +1,80 @@
+//go:build js && wasm
+
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"syscall/js"
+
+	"github.com/sensiblebit/certkit"
+	"github.com/sensiblebit/certkit/internal"
+)
+
+// inspectFiles performs stateless inspection of certificate, key, and CSR data.
+// Unlike addFiles, it does not accumulate into the global MemStore.
+// JS signature: certkitInspect(files: Array<{name: string, data: Uint8Array}>, passwords: string) → Promise<string>
+func inspectFiles(_ js.Value, args []js.Value) any {
+	if len(args) < 1 {
+		return jsError("certkitInspect requires at least 1 argument")
+	}
+
+	filesArg := args[0]
+	length := filesArg.Length()
+
+	var passwords []string
+	if len(args) >= 2 && args[1].Type() == js.TypeString {
+		raw := args[1].String()
+		if raw != "" {
+			for _, p := range strings.Split(raw, ",") {
+				passwords = append(passwords, strings.TrimSpace(p))
+			}
+		}
+	}
+	passwords = certkit.DeduplicatePasswords(passwords)
+
+	handler := js.FuncOf(func(_ js.Value, promiseArgs []js.Value) any {
+		resolve := promiseArgs[0]
+		reject := promiseArgs[1]
+		go func() {
+			var allResults []internal.InspectResult
+			for i := range length {
+				file := filesArg.Index(i)
+				dataJS := file.Get("data")
+				data := make([]byte, dataJS.Length())
+				js.CopyBytesToGo(data, dataJS)
+
+				results := internal.InspectData(data, passwords)
+				allResults = append(allResults, results...)
+			}
+
+			if len(allResults) == 0 {
+				reject.Invoke(js.Global().Get("Error").New("no certificates, keys, or CSRs found"))
+				return
+			}
+
+			// Resolve missing intermediates via AIA before trust annotation.
+			ctx := context.Background()
+			allResults, _ = internal.ResolveInspectAIA(ctx, allResults, jsFetchURL)
+
+			// Annotate trust for certificates.
+			if err := internal.AnnotateInspectTrust(allResults); err != nil {
+				// Non-fatal: trust annotation failure just means
+				// Expired/Trusted fields won't be set.
+				_ = err
+			}
+
+			jsonBytes, err := json.Marshal(allResults)
+			if err != nil {
+				reject.Invoke(js.Global().Get("Error").New("marshaling inspect results: " + err.Error()))
+				return
+			}
+			resolve.Invoke(string(jsonBytes))
+		}()
+		return nil
+	})
+	p := js.Global().Get("Promise").New(handler)
+	handler.Release()
+	return p
+}

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -7,8 +7,6 @@ package main
 
 import (
 	"context"
-	"crypto/x509"
-	"crypto/x509/pkix"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -35,6 +33,7 @@ func main() {
 	js.Global().Set("certkitExportBundles", js.FuncOf(exportBundlesJS))
 	js.Global().Set("certkitReset", js.FuncOf(resetStore))
 	js.Global().Set("certkitValidateCert", js.FuncOf(validateCertificate))
+	js.Global().Set("certkitInspect", js.FuncOf(inspectFiles))
 
 	// Block forever — WASM modules must not exit.
 	select {}
@@ -221,7 +220,7 @@ func getState(_ js.Value, _ []js.Value) any {
 			serial = strings.ToUpper(rec.Cert.SerialNumber.Text(16))
 		}
 
-		ekus := formatEKUs(rec.Cert.ExtKeyUsage)
+		ekus := certkit.FormatEKUs(rec.Cert.ExtKeyUsage)
 		if ekus == nil {
 			ekus = []string{}
 		}
@@ -241,8 +240,8 @@ func getState(_ js.Value, _ []js.Value) any {
 			Expired:   expired,
 			HasKey:    hasKey,
 			Trusted:   trusted,
-			Subject:   formatDN(rec.Cert.Subject),
-			Issuer:    formatDN(rec.Cert.Issuer),
+			Subject:   certkit.FormatDN(rec.Cert.Subject),
+			Issuer:    certkit.FormatDN(rec.Cert.Issuer),
 			SANs:      sans,
 			EKUs:      ekus,
 			Source:    rec.Source,
@@ -324,55 +323,6 @@ func resetStore(_ js.Value, _ []js.Value) any {
 	globalStore.Reset()
 	storeMu.Unlock()
 	return true
-}
-
-// formatDN formats a pkix.Name as a comma-separated string of its components.
-func formatDN(name pkix.Name) string {
-	var parts []string
-	for _, c := range name.Country {
-		parts = append(parts, "C="+c)
-	}
-	for _, s := range name.Province {
-		parts = append(parts, "ST="+s)
-	}
-	for _, l := range name.Locality {
-		parts = append(parts, "L="+l)
-	}
-	for _, o := range name.Organization {
-		parts = append(parts, "O="+o)
-	}
-	for _, ou := range name.OrganizationalUnit {
-		parts = append(parts, "OU="+ou)
-	}
-	if name.CommonName != "" {
-		parts = append(parts, "CN="+name.CommonName)
-	}
-	return strings.Join(parts, ", ")
-}
-
-var extKeyUsageNames = map[x509.ExtKeyUsage]string{
-	x509.ExtKeyUsageAny:                        "Any",
-	x509.ExtKeyUsageServerAuth:                 "Server Authentication",
-	x509.ExtKeyUsageClientAuth:                 "Client Authentication",
-	x509.ExtKeyUsageCodeSigning:                "Code Signing",
-	x509.ExtKeyUsageEmailProtection:            "Email Protection",
-	x509.ExtKeyUsageTimeStamping:               "Time Stamping",
-	x509.ExtKeyUsageOCSPSigning:                "OCSP Signing",
-	x509.ExtKeyUsageMicrosoftServerGatedCrypto: "Microsoft Server Gated Crypto",
-	x509.ExtKeyUsageNetscapeServerGatedCrypto:  "Netscape Server Gated Crypto",
-}
-
-// formatEKUs returns human-readable names for extended key usages.
-func formatEKUs(ekus []x509.ExtKeyUsage) []string {
-	var out []string
-	for _, eku := range ekus {
-		if name, ok := extKeyUsageNames[eku]; ok {
-			out = append(out, name)
-		} else {
-			out = append(out, fmt.Sprintf("Unknown (%d)", int(eku)))
-		}
-	}
-	return out
 }
 
 // hexToBytes decodes a hex string to bytes, returning nil on error.

--- a/dn.go
+++ b/dn.go
@@ -1,0 +1,285 @@
+package certkit
+
+import (
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"encoding/hex"
+	"fmt"
+	"strings"
+)
+
+var extKeyUsageNames = map[x509.ExtKeyUsage]string{
+	x509.ExtKeyUsageAny:                        "Any",
+	x509.ExtKeyUsageServerAuth:                 "Server Authentication",
+	x509.ExtKeyUsageClientAuth:                 "Client Authentication",
+	x509.ExtKeyUsageCodeSigning:                "Code Signing",
+	x509.ExtKeyUsageEmailProtection:            "Email Protection",
+	x509.ExtKeyUsageTimeStamping:               "Time Stamping",
+	x509.ExtKeyUsageOCSPSigning:                "OCSP Signing",
+	x509.ExtKeyUsageMicrosoftServerGatedCrypto: "Microsoft Server Gated Crypto",
+	x509.ExtKeyUsageNetscapeServerGatedCrypto:  "Netscape Server Gated Crypto",
+}
+
+// FormatEKUs returns human-readable names for extended key usages.
+func FormatEKUs(ekus []x509.ExtKeyUsage) []string {
+	var out []string
+	for _, eku := range ekus {
+		if name, ok := extKeyUsageNames[eku]; ok {
+			out = append(out, name)
+		} else {
+			out = append(out, fmt.Sprintf("Unknown (%d)", int(eku)))
+		}
+	}
+	return out
+}
+
+// ekuOIDNames maps well-known Extended Key Usage OIDs to display names.
+// Used for parsing EKU from raw ASN.1 extensions (e.g. in CSRs where Go
+// does not populate typed fields).
+var ekuOIDNames = map[string]string{
+	"1.3.6.1.5.5.7.3.1": "Server Authentication",
+	"1.3.6.1.5.5.7.3.2": "Client Authentication",
+	"1.3.6.1.5.5.7.3.3": "Code Signing",
+	"1.3.6.1.5.5.7.3.4": "Email Protection",
+	"1.3.6.1.5.5.7.3.8": "Time Stamping",
+	"1.3.6.1.5.5.7.3.9": "OCSP Signing",
+	"2.5.29.37.0":       "Any",
+}
+
+// FormatEKUOIDs returns human-readable names for EKU OIDs extracted from
+// raw ASN.1 extension bytes. This is needed for CSRs where Go does not
+// populate ExtKeyUsage typed fields.
+func FormatEKUOIDs(raw []byte) []string {
+	var oids []asn1.ObjectIdentifier
+	if _, err := asn1.Unmarshal(raw, &oids); err != nil {
+		return nil
+	}
+	var out []string
+	for _, oid := range oids {
+		if name, ok := ekuOIDNames[oid.String()]; ok {
+			out = append(out, name)
+		} else {
+			out = append(out, oid.String())
+		}
+	}
+	return out
+}
+
+var keyUsageBits = []struct {
+	bit  x509.KeyUsage
+	name string
+}{
+	{x509.KeyUsageDigitalSignature, "Digital Signature"},
+	{x509.KeyUsageContentCommitment, "Content Commitment"},
+	{x509.KeyUsageKeyEncipherment, "Key Encipherment"},
+	{x509.KeyUsageDataEncipherment, "Data Encipherment"},
+	{x509.KeyUsageKeyAgreement, "Key Agreement"},
+	{x509.KeyUsageCertSign, "Certificate Sign"},
+	{x509.KeyUsageCRLSign, "CRL Sign"},
+	{x509.KeyUsageEncipherOnly, "Encipher Only"},
+	{x509.KeyUsageDecipherOnly, "Decipher Only"},
+}
+
+// FormatKeyUsage returns human-readable names for key usage bits.
+func FormatKeyUsage(ku x509.KeyUsage) []string {
+	var out []string
+	for _, entry := range keyUsageBits {
+		if ku&entry.bit != 0 {
+			out = append(out, entry.name)
+		}
+	}
+	return out
+}
+
+// FormatKeyUsageBitString returns human-readable names for key usage bits
+// extracted from a raw ASN.1 BIT STRING extension value. This is needed for
+// CSRs where Go does not populate KeyUsage typed fields.
+func FormatKeyUsageBitString(raw []byte) []string {
+	var bs asn1.BitString
+	if _, err := asn1.Unmarshal(raw, &bs); err != nil {
+		return nil
+	}
+	// Reconstruct x509.KeyUsage by reading each bit from the BIT STRING,
+	// matching Go's internal parsing in crypto/x509.
+	var ku x509.KeyUsage
+	for i := range 9 {
+		if bs.At(i) != 0 {
+			ku |= 1 << uint(i)
+		}
+	}
+	return FormatKeyUsage(ku)
+}
+
+// oidSubjectAltName is the OID for the Subject Alternative Name extension.
+var oidSubjectAltName = asn1.ObjectIdentifier{2, 5, 29, 17}
+
+// otherNameLabels maps well-known OtherName OIDs to display labels.
+var otherNameLabels = map[string]string{
+	"1.3.6.1.4.1.311.20.2.3":  "UPN",             // Microsoft User Principal Name
+	"1.3.6.1.5.5.7.8.5":       "XMPP",            // id-on-xmppAddr
+	"1.3.6.1.5.5.7.8.7":       "SRV",             // id-on-dnsSRV
+	"1.3.6.1.5.5.7.8.9":       "SmtpUTF8Mailbox", // id-on-SmtpUTF8Mailbox
+	"1.3.6.1.4.1.311.25.1":    "DC-GUID",         // Microsoft DC GUID
+	"2.16.840.1.113733.1.9.7": "Strong-Extranet", // VeriSign SGC
+}
+
+// ParseOtherNameSANs extracts SAN entries that Go's x509 package silently
+// drops: OtherName (tag 0), DirectoryName (tag 4), and RegisteredID (tag 8).
+// Returns formatted strings like "UPN:user@example.com" or
+// "OtherName(1.2.3.4):value". Pass the raw extensions list from a certificate
+// or CSR.
+func ParseOtherNameSANs(extensions []pkix.Extension) []string {
+	for _, ext := range extensions {
+		if !ext.Id.Equal(oidSubjectAltName) {
+			continue
+		}
+		return parseOtherNamesFromSANBytes(ext.Value)
+	}
+	return nil
+}
+
+func parseOtherNamesFromSANBytes(raw []byte) []string {
+	// SAN extension value is: SEQUENCE OF GeneralName
+	var seq asn1.RawValue
+	rest, err := asn1.Unmarshal(raw, &seq)
+	if err != nil || len(rest) > 0 {
+		return nil
+	}
+
+	var sans []string
+	inner := seq.Bytes
+	for len(inner) > 0 {
+		var gn asn1.RawValue
+		inner, err = asn1.Unmarshal(inner, &gn)
+		if err != nil {
+			break
+		}
+		if gn.Class != asn1.ClassContextSpecific {
+			continue
+		}
+		switch gn.Tag {
+		case 0: // otherName [0] IMPLICIT SEQUENCE { OID, [0] EXPLICIT ANY }
+			s := formatOtherName(gn.Bytes)
+			if s != "" {
+				sans = append(sans, s)
+			}
+		case 4: // directoryName [4]
+			var name pkix.RDNSequence
+			if _, err := asn1.Unmarshal(gn.Bytes, &name); err == nil {
+				var pn pkix.Name
+				pn.FillFromRDNSequence(&name)
+				sans = append(sans, "DirName:"+FormatDN(pn))
+			}
+		case 8: // registeredID [8]
+			var oid asn1.ObjectIdentifier
+			if _, err := asn1.Unmarshal(gn.FullBytes, &oid); err == nil {
+				sans = append(sans, "RegisteredID:"+oid.String())
+			}
+		}
+	}
+	return sans
+}
+
+func formatOtherName(data []byte) string {
+	// OtherName ::= SEQUENCE { type-id OID, value [0] EXPLICIT ANY }
+	//
+	// With IMPLICIT tagging (RFC 5280), [0] replaces the SEQUENCE tag so
+	// data starts with the OID directly. Some encoders use EXPLICIT tagging
+	// or wrap in a SEQUENCE, so data may start with a SEQUENCE tag (0x30).
+	content := data
+	var probe asn1.RawValue
+	if _, err := asn1.Unmarshal(data, &probe); err == nil && probe.Tag == asn1.TagSequence && probe.Class == asn1.ClassUniversal {
+		content = probe.Bytes
+	}
+
+	var oid asn1.ObjectIdentifier
+	rest, err := asn1.Unmarshal(content, &oid)
+	if err != nil {
+		return ""
+	}
+
+	label := oid.String()
+	if name, ok := otherNameLabels[label]; ok {
+		label = name
+	}
+
+	// Unwrap the [0] EXPLICIT wrapper to get the inner value.
+	var explicit asn1.RawValue
+	if _, err := asn1.Unmarshal(rest, &explicit); err != nil {
+		return label + ":<unparseable>"
+	}
+
+	// Try common string types (UTF8String, IA5String, PrintableString).
+	var strVal string
+	if _, err := asn1.Unmarshal(explicit.Bytes, &strVal); err == nil {
+		return label + ":" + strVal
+	}
+
+	// Fallback: hex-encode the raw value.
+	return label + ":" + hex.EncodeToString(explicit.Bytes)
+}
+
+// extraOIDLabels maps OIDs not handled by Go's pkix.Name.String() to their
+// standard human-readable labels.
+var extraOIDLabels = map[string]string{
+	"1.2.840.113549.1.9.1": "emailAddress",
+}
+
+// FormatDN formats a pkix.Name as a Distinguished Name string. Unlike
+// pkix.Name.String(), it renders the emailAddress OID (1.2.840.113549.1.9.1)
+// and serialNumber OID (2.5.4.5) with their standard labels instead of raw
+// OID=#hex notation.
+func FormatDN(name pkix.Name) string {
+	s := name.String()
+	for _, atv := range name.Names {
+		oid := atv.Type.String()
+		label, ok := extraOIDLabels[oid]
+		if !ok {
+			continue
+		}
+		value, isStr := atv.Value.(string)
+		if !isStr {
+			continue
+		}
+		// Reconstruct the exact hex that Go's String() produces so the
+		// string replacement is reliable.
+		derBytes, err := asn1.Marshal(atv.Value)
+		if err != nil {
+			continue
+		}
+		old := oid + "=#" + hex.EncodeToString(derBytes)
+		repl := label + "=" + escapeDNValue(value)
+		s = strings.Replace(s, old, repl, 1)
+	}
+	return s
+}
+
+// escapeDNValue escapes special characters in a DN attribute value per RFC 4514.
+func escapeDNValue(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	for i, r := range s {
+		switch r {
+		case ',', '+', '"', '\\', '<', '>', ';':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		case '#':
+			if i == 0 {
+				b.WriteByte('\\')
+			}
+			b.WriteRune(r)
+		case ' ':
+			if i == 0 || i == len(s)-1 {
+				b.WriteByte('\\')
+			}
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	return b.String()
+}

--- a/internal/inspect.go
+++ b/internal/inspect.go
@@ -1,11 +1,13 @@
 package internal
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
 	"crypto/x509"
+	"encoding/asn1"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -17,29 +19,33 @@ import (
 	"github.com/sensiblebit/certkit/internal/certstore"
 )
 
-// InspectResult holds the inspection details for a file.
+// InspectResult holds the inspection details for a single certificate, key, or CSR.
 type InspectResult struct {
-	Type        string   `json:"type"`
-	Subject     string   `json:"subject,omitempty"`
-	Issuer      string   `json:"issuer,omitempty"`
-	Serial      string   `json:"serial,omitempty"`
-	NotBefore   string   `json:"not_before,omitempty"`
-	NotAfter    string   `json:"not_after,omitempty"`
-	CertType    string   `json:"cert_type,omitempty"`
-	Expired     *bool    `json:"expired,omitempty"`
-	Trusted     *bool    `json:"trusted,omitempty"`
-	KeyAlgo     string   `json:"key_algorithm,omitempty"`
-	KeySize     string   `json:"key_size,omitempty"`
-	SANs        []string `json:"sans,omitempty"`
-	SHA256      string   `json:"sha256_fingerprint,omitempty"`
-	SHA1        string   `json:"sha1_fingerprint,omitempty"`
-	SKI         string   `json:"subject_key_id,omitempty"`
-	SKILegacy   string   `json:"subject_key_id_sha1,omitempty"`
-	AKI         string   `json:"authority_key_id,omitempty"`
-	SigAlg      string   `json:"signature_algorithm,omitempty"`
-	KeyType     string   `json:"key_type,omitempty"`
-	CSRSubject  string   `json:"csr_subject,omitempty"`
-	CSRDNSNames []string `json:"csr_dns_names,omitempty"`
+	Type      string   `json:"type"`
+	Subject   string   `json:"subject,omitempty"`
+	Issuer    string   `json:"issuer,omitempty"`
+	Serial    string   `json:"serial,omitempty"`
+	NotBefore string   `json:"not_before,omitempty"`
+	NotAfter  string   `json:"not_after,omitempty"`
+	CertType  string   `json:"cert_type,omitempty"`
+	Expired   *bool    `json:"expired,omitempty"`
+	Trusted   *bool    `json:"trusted,omitempty"`
+	IsCA      *bool    `json:"is_ca,omitempty"`
+	KeyAlgo   string   `json:"key_algorithm,omitempty"`
+	KeySize   string   `json:"key_size,omitempty"`
+	SANs      []string `json:"sans,omitempty"`
+	KeyUsages []string `json:"key_usages,omitempty"`
+	EKUs      []string `json:"ekus,omitempty"`
+	SHA256    string   `json:"sha256_fingerprint,omitempty"`
+	SHA1      string   `json:"sha1_fingerprint,omitempty"`
+	SKI       string   `json:"subject_key_id,omitempty"`
+	SKILegacy string   `json:"subject_key_id_sha1,omitempty"`
+	AKI       string   `json:"authority_key_id,omitempty"`
+	SigAlg    string   `json:"signature_algorithm,omitempty"`
+	KeyType   string   `json:"key_type,omitempty"`
+
+	// CSR-specific fields. Populated only when Type == "csr".
+	CSRSubject string `json:"csr_subject,omitempty"`
 
 	cert *x509.Certificate // unexported; retained for trust annotation
 }
@@ -51,19 +57,22 @@ func InspectFile(path string, passwords []string) ([]InspectResult, error) {
 		return nil, fmt.Errorf("reading %s: %w", path, err)
 	}
 
-	var results []InspectResult
-
-	if certkit.IsPEM(data) {
-		results = append(results, inspectPEMData(data, passwords)...)
-	} else {
-		results = append(results, inspectDERData(data, passwords)...)
-	}
-
+	results := InspectData(data, passwords)
 	if len(results) == 0 {
 		return nil, fmt.Errorf("no certificates, keys, or CSRs found in %s", path)
 	}
 
 	return results, nil
+}
+
+// InspectData parses raw bytes and returns inspection results for all
+// certificates, keys, and CSRs found. It tries PEM first, then DER and
+// container formats (PKCS#12, PKCS#7, JKS).
+func InspectData(data []byte, passwords []string) []InspectResult {
+	if certkit.IsPEM(data) {
+		return inspectPEMData(data, passwords)
+	}
+	return inspectDERData(data, passwords)
 }
 
 func inspectPEMData(data []byte, passwords []string) []InspectResult {
@@ -155,21 +164,28 @@ func inspectDERData(data []byte, passwords []string) []InspectResult {
 
 func inspectCert(cert *x509.Certificate) InspectResult {
 	sans := slices.Concat(cert.DNSNames, certstore.FormatIPAddresses(cert.IPAddresses))
+	sans = append(sans, cert.EmailAddresses...)
 	for _, uri := range cert.URIs {
 		sans = append(sans, uri.String())
 	}
+	sans = append(sans, certkit.ParseOtherNameSANs(cert.Extensions)...)
+
+	isCA := cert.IsCA
 
 	return InspectResult{
 		Type:      "certificate",
-		Subject:   cert.Subject.String(),
-		Issuer:    cert.Issuer.String(),
+		Subject:   certkit.FormatDN(cert.Subject),
+		Issuer:    certkit.FormatDN(cert.Issuer),
 		Serial:    cert.SerialNumber.String(),
 		NotBefore: cert.NotBefore.UTC().Format(time.RFC3339),
 		NotAfter:  cert.NotAfter.UTC().Format(time.RFC3339),
 		CertType:  certkit.GetCertificateType(cert),
+		IsCA:      &isCA,
 		KeyAlgo:   certkit.PublicKeyAlgorithmName(cert.PublicKey),
 		KeySize:   publicKeySize(cert.PublicKey),
 		SANs:      sans,
+		KeyUsages: certkit.FormatKeyUsage(cert.KeyUsage),
+		EKUs:      certkit.FormatEKUs(cert.ExtKeyUsage),
 		SHA256:    certkit.CertFingerprintColonSHA256(cert),
 		SHA1:      certkit.CertFingerprintColonSHA1(cert),
 		SKI:       certkit.CertSKIEmbedded(cert),
@@ -179,15 +195,62 @@ func inspectCert(cert *x509.Certificate) InspectResult {
 	}
 }
 
+// OIDs for extensions we extract from CSRs (Go does not parse these into typed fields).
+var (
+	oidExtKeyUsage         = asn1.ObjectIdentifier{2, 5, 29, 15}
+	oidExtExtKeyUsage      = asn1.ObjectIdentifier{2, 5, 29, 37}
+	oidExtBasicConstraints = asn1.ObjectIdentifier{2, 5, 29, 19}
+)
+
 func inspectCSR(csr *x509.CertificateRequest) InspectResult {
-	return InspectResult{
-		Type:        "csr",
-		CSRSubject:  csr.Subject.String(),
-		KeyAlgo:     certkit.PublicKeyAlgorithmName(csr.PublicKey),
-		KeySize:     publicKeySize(csr.PublicKey),
-		SigAlg:      csr.SignatureAlgorithm.String(),
-		CSRDNSNames: csr.DNSNames,
+	sans := slices.Concat(csr.DNSNames, certstore.FormatIPAddresses(csr.IPAddresses))
+	sans = append(sans, csr.EmailAddresses...)
+	for _, uri := range csr.URIs {
+		sans = append(sans, uri.String())
 	}
+	sans = append(sans, certkit.ParseOtherNameSANs(csr.Extensions)...)
+
+	r := InspectResult{
+		Type:       "csr",
+		CSRSubject: certkit.FormatDN(csr.Subject),
+		KeyAlgo:    certkit.PublicKeyAlgorithmName(csr.PublicKey),
+		KeySize:    publicKeySize(csr.PublicKey),
+		SigAlg:     csr.SignatureAlgorithm.String(),
+		SANs:       sans,
+	}
+
+	// Compute SKI from the CSR's public key.
+	if ski, err := certkit.ComputeSKI(csr.PublicKey); err == nil {
+		r.SKI = certkit.ColonHex(ski)
+	}
+
+	// Parse requested extensions that Go does not populate as typed fields.
+	for _, ext := range csr.Extensions {
+		switch {
+		case ext.Id.Equal(oidExtKeyUsage):
+			r.KeyUsages = certkit.FormatKeyUsageBitString(ext.Value)
+		case ext.Id.Equal(oidExtExtKeyUsage):
+			r.EKUs = certkit.FormatEKUOIDs(ext.Value)
+		case ext.Id.Equal(oidExtBasicConstraints):
+			isCA := parseBasicConstraintsCA(ext.Value)
+			r.IsCA = &isCA
+		}
+	}
+
+	return r
+}
+
+// parseBasicConstraintsCA extracts the isCA boolean from a raw Basic
+// Constraints extension value.
+func parseBasicConstraintsCA(raw []byte) bool {
+	var bc struct {
+		IsCA       bool `asn1:"optional"`
+		MaxPathLen int  `asn1:"optional,default:-1"`
+	}
+	if _, err := asn1.Unmarshal(raw, &bc); err != nil {
+		return false
+	}
+	return bc.IsCA
 }
 
 func inspectKey(key any) InspectResult {
@@ -239,6 +302,44 @@ func privateKeySize(key any) string {
 	default:
 		return "unknown"
 	}
+}
+
+// ResolveInspectAIA fetches missing intermediate certificates via AIA for the
+// given inspect results. It creates a temporary MemStore, adds all certificates
+// from the results, resolves AIA using the provided fetcher, inspects any newly
+// fetched certificates, and returns the extended results along with warnings.
+func ResolveInspectAIA(ctx context.Context, results []InspectResult, fetch certstore.AIAFetcher) ([]InspectResult, []string) {
+	store := certstore.NewMemStore()
+	for _, r := range results {
+		if r.cert != nil {
+			_ = store.HandleCertificate(r.cert, "inspect")
+		}
+	}
+
+	if !certstore.HasUnresolvedIssuers(store) {
+		return results, nil
+	}
+
+	// Track existing certs so we can identify newly fetched ones.
+	existing := make(map[string]bool)
+	for _, rec := range store.AllCertsFlat() {
+		existing[certkit.CertFingerprint(rec.Cert)] = true
+	}
+
+	warnings := certstore.ResolveAIA(ctx, certstore.ResolveAIAInput{
+		Store: store,
+		Fetch: fetch,
+	})
+
+	for _, rec := range store.AllCertsFlat() {
+		fp := certkit.CertFingerprint(rec.Cert)
+		if existing[fp] {
+			continue
+		}
+		results = append(results, inspectCert(rec.Cert))
+	}
+
+	return results, warnings
 }
 
 // AnnotateInspectTrust sets the Expired and Trusted fields on certificate
@@ -305,6 +406,9 @@ func formatInspectText(results []InspectResult) string {
 			fmt.Fprintf(&sb, "  Issuer:      %s\n", r.Issuer)
 			fmt.Fprintf(&sb, "  Serial:      %s\n", r.Serial)
 			fmt.Fprintf(&sb, "  Type:        %s\n", r.CertType)
+			if r.IsCA != nil {
+				fmt.Fprintf(&sb, "  CA:          %s\n", boolYesNo(*r.IsCA))
+			}
 			fmt.Fprintf(&sb, "  Not Before:  %s\n", r.NotBefore)
 			fmt.Fprintf(&sb, "  Not After:   %s\n", r.NotAfter)
 			if r.Expired != nil {
@@ -315,6 +419,12 @@ func formatInspectText(results []InspectResult) string {
 			}
 			fmt.Fprintf(&sb, "  Key:         %s %s\n", r.KeyAlgo, r.KeySize)
 			fmt.Fprintf(&sb, "  Signature:   %s\n", r.SigAlg)
+			if len(r.KeyUsages) > 0 {
+				fmt.Fprintf(&sb, "  Key Usage:   %s\n", strings.Join(r.KeyUsages, ", "))
+			}
+			if len(r.EKUs) > 0 {
+				fmt.Fprintf(&sb, "  EKU:         %s\n", strings.Join(r.EKUs, ", "))
+			}
 			fmt.Fprintf(&sb, "  SHA-256:     %s\n", r.SHA256)
 			fmt.Fprintf(&sb, "  SHA-1:       %s\n", r.SHA1)
 			if r.SKI != "" {
@@ -326,10 +436,22 @@ func formatInspectText(results []InspectResult) string {
 		case "csr":
 			fmt.Fprintf(&sb, "Certificate Signing Request:\n")
 			fmt.Fprintf(&sb, "  Subject:     %s\n", r.CSRSubject)
+			if len(r.SANs) > 0 {
+				fmt.Fprintf(&sb, "  SANs:        %s\n", strings.Join(r.SANs, ", "))
+			}
+			if r.IsCA != nil {
+				fmt.Fprintf(&sb, "  CA:          %s\n", boolYesNo(*r.IsCA))
+			}
 			fmt.Fprintf(&sb, "  Key:         %s %s\n", r.KeyAlgo, r.KeySize)
 			fmt.Fprintf(&sb, "  Signature:   %s\n", r.SigAlg)
-			if len(r.CSRDNSNames) > 0 {
-				fmt.Fprintf(&sb, "  DNS Names:   %s\n", strings.Join(r.CSRDNSNames, ", "))
+			if len(r.KeyUsages) > 0 {
+				fmt.Fprintf(&sb, "  Key Usage:   %s\n", strings.Join(r.KeyUsages, ", "))
+			}
+			if len(r.EKUs) > 0 {
+				fmt.Fprintf(&sb, "  EKU:         %s\n", strings.Join(r.EKUs, ", "))
+			}
+			if r.SKI != "" {
+				fmt.Fprintf(&sb, "  SKI:         %s\n", r.SKI)
 			}
 		case "private_key":
 			fmt.Fprintf(&sb, "Private Key:\n")

--- a/internal/inspect_test.go
+++ b/internal/inspect_test.go
@@ -285,14 +285,14 @@ func TestInspectFile_CSR(t *testing.T) {
 	if !strings.Contains(csrResult.CSRSubject, "csr.example.com") {
 		t.Errorf("CSR subject should contain CN, got %s", csrResult.CSRSubject)
 	}
-	if len(csrResult.CSRDNSNames) != 2 {
-		t.Fatalf("expected 2 DNS names, got %d", len(csrResult.CSRDNSNames))
+	if len(csrResult.SANs) != 2 {
+		t.Fatalf("expected 2 SANs, got %d: %v", len(csrResult.SANs), csrResult.SANs)
 	}
-	if !slices.Contains(csrResult.CSRDNSNames, "csr.example.com") {
-		t.Error("CSR DNS names should contain csr.example.com")
+	if !slices.Contains(csrResult.SANs, "csr.example.com") {
+		t.Error("CSR SANs should contain csr.example.com")
 	}
-	if !slices.Contains(csrResult.CSRDNSNames, "www.csr.example.com") {
-		t.Error("CSR DNS names should contain www.csr.example.com")
+	if !slices.Contains(csrResult.SANs, "www.csr.example.com") {
+		t.Error("CSR SANs should contain www.csr.example.com")
 	}
 }
 
@@ -682,15 +682,15 @@ func TestFormatInspectResults_Text(t *testing.T) {
 			mustContain: []string{"Certificate:", "CN=test", "RSA 2048", "AA:BB", "Private Key:"},
 		},
 		{
-			name: "CSR with DNS names",
+			name: "CSR with SANs",
 			results: []InspectResult{
 				{
-					Type:        "csr",
-					CSRSubject:  "CN=example.com,O=Test Corp",
-					KeyAlgo:     "ECDSA",
-					KeySize:     "P-256",
-					SigAlg:      "SHA256-RSA",
-					CSRDNSNames: []string{"example.com", "www.example.com"},
+					Type:       "csr",
+					CSRSubject: "CN=example.com,O=Test Corp",
+					KeyAlgo:    "ECDSA",
+					KeySize:    "P-256",
+					SigAlg:     "SHA256-RSA",
+					SANs:       []string{"example.com", "www.example.com"},
 				},
 			},
 			mustContain: []string{
@@ -702,12 +702,12 @@ func TestFormatInspectResults_Text(t *testing.T) {
 			},
 		},
 		{
-			name: "CSR without DNS names",
+			name: "CSR without SANs",
 			results: []InspectResult{
 				{Type: "csr", CSRSubject: "CN=test", KeyAlgo: "RSA", KeySize: "2048", SigAlg: "SHA256-RSA"},
 			},
 			mustContain:    []string{"Certificate Signing Request:"},
-			mustNotContain: []string{"DNS Names:"},
+			mustNotContain: []string{"SANs:"},
 		},
 		{
 			name: "certificate with expired and trusted annotations",

--- a/web/public/app.js
+++ b/web/public/app.js
@@ -1,6 +1,6 @@
 import { formatDate, escapeHTML } from "./utils.js";
 
-// DOM references
+// DOM references — Scan page
 const dropZone = document.getElementById("drop-zone");
 const fileInput = document.getElementById("file-input");
 const passwordsInput = document.getElementById("passwords");
@@ -25,10 +25,25 @@ const filterUnmatched = document.getElementById("filter-unmatched");
 const filterUntrusted = document.getElementById("filter-untrusted");
 const selectAll = document.getElementById("select-all");
 
+// DOM references — Inspect page
+const inspectDropZone = document.getElementById("inspect-drop-zone");
+const inspectFileInput = document.getElementById("inspect-file-input");
+const inspectPasswordsInput = document.getElementById("inspect-passwords");
+const inspectStatusBar = document.getElementById("inspect-status");
+const inspectStatusText = document.getElementById("inspect-status-text");
+const inspectResultsSection = document.getElementById("inspect-results");
+const inspectCards = document.getElementById("inspect-cards");
+const inspectResetBtn = document.getElementById("inspect-reset-btn");
+
+// DOM references — Page tabs
+const pageScan = document.getElementById("page-scan");
+const pageInspect = document.getElementById("page-inspect");
+
 // State
 let wasmReady = false;
 let aiaComplete = false;
 let processing = false;
+let activePage = "scan";
 const selectedSKIs = new Set();
 const certSort = { column: "expiry", direction: "desc" };
 const keySort = { column: "match", direction: "desc" };
@@ -107,7 +122,24 @@ loadWasm().catch((err) => {
   showStatus(`Failed to load WASM: ${err.message}`, true);
 });
 
-// --- Drop Zone ---
+// --- Page-level Tabs (Scan / Inspect) ---
+
+function switchPage(page) {
+  activePage = page;
+  for (const btn of document.querySelectorAll(".page-tab")) {
+    const isActive = btn.dataset.page === page;
+    btn.classList.toggle("active", isActive);
+    btn.setAttribute("aria-selected", String(isActive));
+  }
+  pageScan.hidden = page !== "scan";
+  pageInspect.hidden = page !== "inspect";
+}
+
+for (const btn of document.querySelectorAll(".page-tab")) {
+  btn.addEventListener("click", () => switchPage(btn.dataset.page));
+}
+
+// --- Drop Zone (Scan) ---
 
 dropZone.addEventListener("click", () => fileInput.click());
 
@@ -169,14 +201,22 @@ document.addEventListener("paste", async (e) => {
   const text = e.clipboardData.getData("text/plain");
   if (!text.trim()) return;
   if (text.length > MAX_PASTE_BYTES) {
-    showStatus("Pasted data is too large (max 1 MB)", true);
+    if (activePage === "inspect") {
+      showInspectStatus("Pasted data is too large (max 1 MB)", true);
+    } else {
+      showStatus("Pasted data is too large (max 1 MB)", true);
+    }
     return;
   }
   const data = new TextEncoder().encode(text);
-  await addFileObjects(
-    [{ name: "pasted.pem", data }],
-    "Processing pasted data...",
-  );
+  if (activePage === "inspect") {
+    await inspectFileObjects([{ name: "pasted.pem", data }]);
+  } else {
+    await addFileObjects(
+      [{ name: "pasted.pem", data }],
+      "Processing pasted data...",
+    );
+  }
 });
 
 // --- File Collection (supports recursive folder reading) ---
@@ -313,6 +353,223 @@ window.certkitOnAIAProgress = function (completed, total) {
   progressFill.setAttribute("aria-valuenow", String(pct));
   progressLabel.textContent = `${pct}%`;
 };
+
+// --- Drop Zone (Inspect) ---
+
+inspectDropZone.addEventListener("click", () => inspectFileInput.click());
+
+inspectDropZone.addEventListener("dragover", (e) => {
+  e.preventDefault();
+  inspectDropZone.classList.add("dragging");
+});
+
+inspectDropZone.addEventListener("dragleave", () => {
+  inspectDropZone.classList.remove("dragging");
+});
+
+inspectDropZone.addEventListener("drop", async (e) => {
+  e.preventDefault();
+  inspectDropZone.classList.remove("dragging");
+  if (!wasmReady || processing) return;
+
+  const items = e.dataTransfer.items;
+  if (items) {
+    const files = await collectFiles(items);
+    if (files.length > 0) {
+      await processInspectFiles(files);
+    }
+  }
+});
+
+inspectFileInput.addEventListener("change", async () => {
+  if (!wasmReady || processing) return;
+  const files = Array.from(inspectFileInput.files);
+  if (files.length > 0) {
+    await processInspectFiles(files);
+  }
+  inspectFileInput.value = "";
+});
+
+inspectDropZone.addEventListener("keydown", (e) => {
+  if (e.key === "Enter" || e.key === " ") {
+    e.preventDefault();
+    inspectFileInput.click();
+  }
+});
+
+// --- Inspect File Processing ---
+
+async function processInspectFiles(files) {
+  if (processing) return;
+  let fileObjects;
+  try {
+    fileObjects = await Promise.all(
+      files.map(async (f) => {
+        const buf = await f.arrayBuffer();
+        return { name: f.name, data: new Uint8Array(buf) };
+      }),
+    );
+  } catch (err) {
+    showInspectStatus(`Error reading files: ${err.message}`, true);
+    return;
+  }
+  await inspectFileObjects(fileObjects);
+}
+
+async function inspectFileObjects(fileObjects) {
+  processing = true;
+  showInspectStatus("Inspecting...", false);
+
+  try {
+    const resultJSON = await certkitInspect(
+      fileObjects,
+      inspectPasswordsInput.value.trim(),
+    );
+    const results = JSON.parse(resultJSON);
+
+    if (!results || results.length === 0) {
+      showInspectStatus("No certificates, keys, or CSRs found in input.", true);
+      return;
+    }
+
+    hideInspectStatus();
+    renderInspectResults(results);
+  } catch (err) {
+    showInspectStatus(`Error: ${err.message}`, true);
+  } finally {
+    processing = false;
+  }
+}
+
+// --- Inspect Results Rendering ---
+
+function renderInspectResults(results) {
+  inspectResultsSection.hidden = false;
+  inspectCards.innerHTML = "";
+
+  for (const r of results) {
+    switch (r.type) {
+      case "certificate":
+        inspectCards.appendChild(buildCertCard(r));
+        break;
+      case "csr":
+        inspectCards.appendChild(buildCSRCard(r));
+        break;
+      case "private_key":
+        inspectCards.appendChild(buildKeyCard(r));
+        break;
+    }
+  }
+}
+
+function buildCertCard(r) {
+  const card = document.createElement("div");
+  card.className = "inspect-card";
+
+  const typeBadge = `<span class="badge badge-${escapeHTML(r.cert_type || "leaf")}">${escapeHTML(r.cert_type || "unknown")}</span>`;
+  const badges = [typeBadge];
+  if (r.expired === true) {
+    badges.push(`<span class="badge badge-expired">expired</span>`);
+  }
+  if (r.trusted === true) {
+    badges.push(`<span class="badge badge-match">trusted</span>`);
+  } else if (r.trusted === false) {
+    badges.push(`<span class="badge badge-expired">untrusted</span>`);
+  }
+
+  card.innerHTML = `
+    <div class="inspect-card-header">Certificate ${badges.join(" ")}</div>
+    <div class="inspect-card-body">
+      <div class="metadata-grid">
+        ${metaRow("Subject", r.subject)}
+        ${metaRow("Issuer", r.issuer)}
+        ${r.sans && r.sans.length > 0 ? metaRow("SANs", r.sans.join(", ")) : ""}
+        ${metaRow("Serial", r.serial, true)}
+        ${metaRow("Type", r.cert_type)}
+        ${r.is_ca != null ? metaRow("CA", r.is_ca ? "Yes" : "No") : ""}
+        ${metaRow("Not Before", formatDate(r.not_before))}
+        ${metaRow("Not After", formatDate(r.not_after))}
+        ${metaRow("Key", `${r.key_algorithm || ""} ${r.key_size || ""}`.trim())}
+        ${metaRow("Signature", r.signature_algorithm)}
+        ${r.key_usages && r.key_usages.length > 0 ? metaRow("Key Usage", r.key_usages.join(", ")) : ""}
+        ${r.ekus && r.ekus.length > 0 ? metaRow("EKU", r.ekus.join(", ")) : ""}
+        ${metaRow("SHA-256", r.sha256_fingerprint, true)}
+        ${metaRow("SHA-1", r.sha1_fingerprint, true)}
+        ${r.subject_key_id ? metaRow("SKI", r.subject_key_id, true) : ""}
+        ${r.authority_key_id ? metaRow("AKI", r.authority_key_id, true) : ""}
+      </div>
+    </div>`;
+  return card;
+}
+
+function buildCSRCard(r) {
+  const card = document.createElement("div");
+  card.className = "inspect-card";
+
+  card.innerHTML = `
+    <div class="inspect-card-header">Certificate Signing Request</div>
+    <div class="inspect-card-body">
+      <div class="metadata-grid">
+        ${metaRow("Subject", r.csr_subject)}
+        ${r.sans && r.sans.length > 0 ? metaRow("SANs", r.sans.join(", ")) : ""}
+        ${r.is_ca != null ? metaRow("CA", r.is_ca ? "Yes" : "No") : ""}
+        ${metaRow("Key", `${r.key_algorithm || ""} ${r.key_size || ""}`.trim())}
+        ${metaRow("Signature", r.signature_algorithm)}
+        ${r.key_usages && r.key_usages.length > 0 ? metaRow("Key Usage", r.key_usages.join(", ")) : ""}
+        ${r.ekus && r.ekus.length > 0 ? metaRow("EKU", r.ekus.join(", ")) : ""}
+        ${r.subject_key_id ? metaRow("SKI", r.subject_key_id, true) : ""}
+      </div>
+    </div>`;
+  return card;
+}
+
+function buildKeyCard(r) {
+  const card = document.createElement("div");
+  card.className = "inspect-card";
+
+  card.innerHTML = `
+    <div class="inspect-card-header">Private Key</div>
+    <div class="inspect-card-body">
+      <div class="metadata-grid">
+        ${metaRow("Type", r.key_type)}
+        ${metaRow("Size", r.key_size)}
+        ${r.subject_key_id ? metaRow("SKI (SHA-256)", r.subject_key_id, true) : ""}
+        ${r.subject_key_id_sha1 ? metaRow("SKI (SHA-1)", r.subject_key_id_sha1, true) : ""}
+      </div>
+    </div>`;
+  return card;
+}
+
+function metaRow(label, value, mono = false) {
+  if (!value && value !== 0) return "";
+  const cls = mono ? " mono" : "";
+  return `<div class="metadata-label">${escapeHTML(label)}</div><div class="metadata-value${cls}">${escapeHTML(String(value))}</div>`;
+}
+
+// --- Inspect Status Helpers ---
+
+function showInspectStatus(message, isError = false) {
+  inspectStatusBar.hidden = false;
+  inspectStatusText.textContent = message;
+  inspectStatusBar.className = "status-bar";
+  if (isError) inspectStatusBar.style.color = "var(--danger)";
+  else {
+    inspectStatusBar.classList.add("processing");
+    inspectStatusBar.style.color = "";
+  }
+}
+
+function hideInspectStatus() {
+  inspectStatusBar.hidden = true;
+}
+
+// --- Inspect Reset ---
+
+inspectResetBtn.addEventListener("click", () => {
+  inspectResultsSection.hidden = true;
+  inspectCards.innerHTML = "";
+  hideInspectStatus();
+});
 
 // --- Category Tabs ---
 

--- a/web/public/index.html
+++ b/web/public/index.html
@@ -36,215 +36,308 @@
     </header>
 
     <main>
-      <section class="explainer">
-        <p>
-          Drop your certificate and key files below. certkit will parse them,
-          match private keys to their certificates by Subject Key Identifier,
-          resolve certificate chains via AIA, verify trust against the Mozilla
-          root store, and package everything into organized bundles you can
-          deploy directly.
-        </p>
-        <details>
-          <summary>Supported formats and how it works</summary>
-          <ul>
-            <li>
-              <strong>Formats:</strong> PEM, DER, PKCS#12 (.p12/.pfx), PKCS#7
-              (.p7b), JKS (.jks), and ZIP/TAR archives containing any of the
-              above.
-            </li>
-            <li>
-              <strong>Key matching:</strong> Private keys are matched to
-              certificates using the Subject Key Identifier (SKI). Drop them in
-              any order, from any number of files.
-            </li>
-            <li>
-              <strong>Chain resolution:</strong> Missing intermediate
-              certificates are fetched automatically via Authority Information
-              Access (AIA) URLs embedded in your certs.
-            </li>
-            <li>
-              <strong>Trust validation:</strong> Each certificate is verified
-              against the embedded Mozilla CA root store. Untrusted and expired
-              certificates are flagged with badges.
-            </li>
-            <li>
-              <strong>Export:</strong> Select which bundles to include, then
-              download a ZIP containing the leaf cert, chain, full chain,
-              intermediates, root, private key, and PKCS#12 archive for each.
-            </li>
-            <li>
-              <strong>Privacy:</strong> Everything runs locally in your browser
-              via WebAssembly. No files are uploaded to any server.
-            </li>
-          </ul>
-        </details>
-      </section>
+      <nav class="page-tabs" role="tablist">
+        <button
+          class="page-tab active"
+          data-page="scan"
+          role="tab"
+          aria-selected="true"
+        >
+          Scan
+        </button>
+        <button
+          class="page-tab"
+          data-page="inspect"
+          role="tab"
+          aria-selected="false"
+        >
+          Inspect
+        </button>
+      </nav>
 
-      <section
-        id="drop-zone"
-        class="drop-zone"
-        tabindex="0"
-        role="button"
-        aria-label="Drop files here or click to browse"
-      >
-        <div class="drop-zone-content">
-          <svg
-            width="48"
-            height="48"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="1.5"
-            stroke-linecap="round"
-            stroke-linejoin="round"
-          >
-            <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
-            <polyline points="17 8 12 3 7 8" />
-            <line x1="12" y1="3" x2="12" y2="15" />
-          </svg>
-          <p>Drop files or folders here</p>
-          <p class="hint">
-            PEM, DER, PKCS#12, PKCS#7, JKS, ZIP — drop, browse, or paste
+      <div id="page-scan" class="page-panel">
+        <section class="explainer">
+          <p>
+            Drop your certificate and key files below. certkit will parse them,
+            match private keys to their certificates by Subject Key Identifier,
+            resolve certificate chains via AIA, verify trust against the Mozilla
+            root store, and package everything into organized bundles you can
+            deploy directly.
           </p>
-        </div>
-        <input type="file" id="file-input" multiple hidden />
-      </section>
+          <details>
+            <summary>Supported formats and how it works</summary>
+            <ul>
+              <li>
+                <strong>Formats:</strong> PEM, DER, PKCS#12 (.p12/.pfx), PKCS#7
+                (.p7b), JKS (.jks), and ZIP/TAR archives containing any of the
+                above.
+              </li>
+              <li>
+                <strong>Key matching:</strong> Private keys are matched to
+                certificates using the Subject Key Identifier (SKI). Drop them
+                in any order, from any number of files.
+              </li>
+              <li>
+                <strong>Chain resolution:</strong> Missing intermediate
+                certificates are fetched automatically via Authority Information
+                Access (AIA) URLs embedded in your certs.
+              </li>
+              <li>
+                <strong>Trust validation:</strong> Each certificate is verified
+                against the embedded Mozilla CA root store. Untrusted and
+                expired certificates are flagged with badges.
+              </li>
+              <li>
+                <strong>Export:</strong> Select which bundles to include, then
+                download a ZIP containing the leaf cert, chain, full chain,
+                intermediates, root, private key, and PKCS#12 archive for each.
+              </li>
+              <li>
+                <strong>Privacy:</strong> Everything runs locally in your
+                browser via WebAssembly. No files are uploaded to any server.
+              </li>
+            </ul>
+          </details>
+        </section>
 
-      <section class="options-section">
-        <div class="option-row">
-          <label for="passwords"
-            >Passwords
-            <span class="hint"
-              >(comma-separated, for encrypted files)</span
-            ></label
-          >
-          <input
-            type="text"
-            id="passwords"
-            placeholder="password1, password2, ..."
-          />
-        </div>
-      </section>
-
-      <section id="status-bar" class="status-bar" hidden>
-        <span id="status-text">Loading WASM...</span>
-        <div id="progress-container" class="progress-container" hidden>
-          <div class="progress-bar">
-            <div
-              id="progress-fill"
-              class="progress-fill"
-              role="progressbar"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              aria-valuenow="0"
-            ></div>
+        <section
+          id="drop-zone"
+          class="drop-zone"
+          tabindex="0"
+          role="button"
+          aria-label="Drop files here or click to browse"
+        >
+          <div class="drop-zone-content">
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="17 8 12 3 7 8" />
+              <line x1="12" y1="3" x2="12" y2="15" />
+            </svg>
+            <p>Drop files or folders here</p>
+            <p class="hint">
+              PEM, DER, PKCS#12, PKCS#7, JKS, ZIP — drop, browse, or paste
+            </p>
           </div>
-          <span id="progress-label" class="progress-label"></span>
-        </div>
-      </section>
+          <input type="file" id="file-input" multiple hidden />
+        </section>
 
-      <section id="results-section" hidden>
-        <div class="results-header">
-          <h2>Results</h2>
-          <div class="results-actions">
-            <button id="export-btn" class="btn btn-primary" disabled>
-              Export Bundles (ZIP)
+        <section class="options-section">
+          <div class="option-row">
+            <label for="passwords"
+              >Passwords
+              <span class="hint"
+                >(comma-separated, for encrypted files)</span
+              ></label
+            >
+            <input
+              type="text"
+              id="passwords"
+              placeholder="password1, password2, ..."
+            />
+          </div>
+        </section>
+
+        <section id="status-bar" class="status-bar" hidden>
+          <span id="status-text">Loading WASM...</span>
+          <div id="progress-container" class="progress-container" hidden>
+            <div class="progress-bar">
+              <div
+                id="progress-fill"
+                class="progress-fill"
+                role="progressbar"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                aria-valuenow="0"
+              ></div>
+            </div>
+            <span id="progress-label" class="progress-label"></span>
+          </div>
+        </section>
+
+        <section id="results-section" hidden>
+          <div class="results-header">
+            <h2>Results</h2>
+            <div class="results-actions">
+              <button id="export-btn" class="btn btn-primary" disabled>
+                Export Bundles (ZIP)
+              </button>
+              <button id="reset-btn" class="btn btn-secondary">Reset</button>
+            </div>
+          </div>
+
+          <div id="summary" class="summary"></div>
+
+          <div id="filters" class="filters" hidden>
+            <label class="filter-label"
+              ><input type="checkbox" id="filter-expired" /> Hide expired</label
+            >
+            <label class="filter-label"
+              ><input type="checkbox" id="filter-untrusted" /> Hide
+              untrusted</label
+            >
+            <label class="filter-label"
+              ><input type="checkbox" id="filter-unmatched" /> Hide
+              unmatched</label
+            >
+          </div>
+
+          <nav class="category-tabs" id="category-tabs" role="tablist">
+            <button
+              class="cat-tab active"
+              data-cat="leaf"
+              role="tab"
+              aria-selected="true"
+            >
+              Leaf
             </button>
-            <button id="reset-btn" class="btn btn-secondary">Reset</button>
-          </div>
-        </div>
+            <button
+              class="cat-tab"
+              data-cat="intermediate"
+              role="tab"
+              aria-selected="false"
+            >
+              Intermediate
+            </button>
+            <button
+              class="cat-tab"
+              data-cat="root"
+              role="tab"
+              aria-selected="false"
+            >
+              Root
+            </button>
+            <button
+              class="cat-tab"
+              data-cat="keys"
+              role="tab"
+              aria-selected="false"
+            >
+              Keys
+            </button>
+          </nav>
 
-        <div id="summary" class="summary"></div>
-
-        <div id="filters" class="filters" hidden>
-          <label class="filter-label"
-            ><input type="checkbox" id="filter-expired" /> Hide expired</label
-          >
-          <label class="filter-label"
-            ><input type="checkbox" id="filter-untrusted" /> Hide
-            untrusted</label
-          >
-          <label class="filter-label"
-            ><input type="checkbox" id="filter-unmatched" /> Hide
-            unmatched</label
-          >
-        </div>
-
-        <nav class="category-tabs" id="category-tabs" role="tablist">
-          <button
-            class="cat-tab active"
-            data-cat="leaf"
-            role="tab"
-            aria-selected="true"
-          >
-            Leaf
-          </button>
-          <button
-            class="cat-tab"
-            data-cat="intermediate"
-            role="tab"
-            aria-selected="false"
-          >
-            Intermediate
-          </button>
-          <button
-            class="cat-tab"
-            data-cat="root"
-            role="tab"
-            aria-selected="false"
-          >
-            Root
-          </button>
-          <button
-            class="cat-tab"
-            data-cat="keys"
-            role="tab"
-            aria-selected="false"
-          >
-            Keys
-          </button>
-        </nav>
-
-        <div id="cert-table-container" class="table-container">
-          <table id="results-table">
-            <thead>
-              <tr>
-                <th class="col-select">
-                  <input type="checkbox" id="select-all" title="Select all" />
-                </th>
-                <th data-sort="cn">CN / Name</th>
-                <th data-sort="serial" class="serial">Serial</th>
-                <th data-sort="key_type">Key Type</th>
-                <th data-sort="expiry">Expiry</th>
-                <th data-sort="trusted">Trusted</th>
-                <th data-sort="match">Key Match</th>
-              </tr>
-            </thead>
-            <tbody id="results-body"></tbody>
-          </table>
-        </div>
-
-        <div id="keys-section" hidden>
-          <div class="table-container">
-            <table id="keys-table">
+          <div id="cert-table-container" class="table-container">
+            <table id="results-table">
               <thead>
                 <tr>
-                  <th data-sort="type">Type</th>
-                  <th data-sort="bits">Bits</th>
-                  <th data-sort="ski">SKI</th>
-                  <th data-sort="match">Cert Match</th>
+                  <th class="col-select">
+                    <input type="checkbox" id="select-all" title="Select all" />
+                  </th>
+                  <th data-sort="cn">CN / Name</th>
+                  <th data-sort="serial" class="serial">Serial</th>
+                  <th data-sort="key_type">Key Type</th>
+                  <th data-sort="expiry">Expiry</th>
+                  <th data-sort="trusted">Trusted</th>
+                  <th data-sort="match">Key Match</th>
                 </tr>
               </thead>
-              <tbody id="keys-body"></tbody>
+              <tbody id="results-body"></tbody>
             </table>
           </div>
-        </div>
 
-        <div id="warnings-section" hidden>
-          <h3>Warnings</h3>
-          <ul id="warnings-list"></ul>
-        </div>
-      </section>
+          <div id="keys-section" hidden>
+            <div class="table-container">
+              <table id="keys-table">
+                <thead>
+                  <tr>
+                    <th data-sort="type">Type</th>
+                    <th data-sort="bits">Bits</th>
+                    <th data-sort="ski">SKI</th>
+                    <th data-sort="match">Cert Match</th>
+                  </tr>
+                </thead>
+                <tbody id="keys-body"></tbody>
+              </table>
+            </div>
+          </div>
+
+          <div id="warnings-section" hidden>
+            <h3>Warnings</h3>
+            <ul id="warnings-list"></ul>
+          </div>
+        </section>
+      </div>
+
+      <div id="page-inspect" class="page-panel" hidden>
+        <section class="explainer">
+          <p>
+            Drop or paste a certificate, key, CSR, or bundle to inspect it.
+            Shows detailed information including SANs, fingerprints, EKUs, trust
+            status, and more.
+          </p>
+        </section>
+
+        <section
+          id="inspect-drop-zone"
+          class="drop-zone"
+          tabindex="0"
+          role="button"
+          aria-label="Drop a file here or click to browse"
+        >
+          <div class="drop-zone-content">
+            <svg
+              width="48"
+              height="48"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+            >
+              <path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" />
+              <polyline points="17 8 12 3 7 8" />
+              <line x1="12" y1="3" x2="12" y2="15" />
+            </svg>
+            <p>Drop a file here</p>
+            <p class="hint">
+              PEM, DER, PKCS#12, PKCS#7, JKS, CSR — drop, browse, or paste
+            </p>
+          </div>
+          <input type="file" id="inspect-file-input" multiple hidden />
+        </section>
+
+        <section class="options-section">
+          <div class="option-row">
+            <label for="inspect-passwords"
+              >Passwords
+              <span class="hint"
+                >(comma-separated, for encrypted files)</span
+              ></label
+            >
+            <input
+              type="text"
+              id="inspect-passwords"
+              placeholder="password1, password2, ..."
+            />
+          </div>
+        </section>
+
+        <section id="inspect-status" class="status-bar" hidden>
+          <span id="inspect-status-text"></span>
+        </section>
+
+        <section id="inspect-results" hidden>
+          <div class="results-header">
+            <h2>Inspection</h2>
+            <div class="results-actions">
+              <button id="inspect-reset-btn" class="btn btn-secondary">
+                Reset
+              </button>
+            </div>
+          </div>
+          <div id="inspect-cards"></div>
+        </section>
+      </div>
     </main>
 
     <footer>

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -88,6 +88,77 @@ header p {
   font-size: 0.875rem;
 }
 
+/* --- Page-level Tabs (Scan / Inspect) --- */
+
+.page-tabs {
+  display: flex;
+  gap: 0;
+  margin-bottom: 1.25rem;
+  border-bottom: 2px solid var(--border);
+}
+
+.page-tab {
+  padding: 0.5rem 1.25rem;
+  border: none;
+  background: none;
+  color: var(--fg-secondary);
+  font-family: var(--font-sans);
+  font-size: 0.9375rem;
+  font-weight: 500;
+  cursor: pointer;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -2px;
+  transition:
+    color 0.15s,
+    border-color 0.15s;
+}
+
+.page-tab:hover {
+  color: var(--fg);
+}
+
+.page-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+}
+
+.page-panel[hidden] {
+  display: none;
+}
+
+/* --- Inspect Cards --- */
+
+.inspect-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 1rem;
+  overflow: hidden;
+}
+
+.inspect-card-header {
+  padding: 0.625rem 0.75rem;
+  background: var(--bg-secondary);
+  font-weight: 600;
+  font-size: 0.875rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.inspect-card-body {
+  padding: 0;
+}
+
+.inspect-card-body .metadata-grid {
+  border-top: none;
+  margin-top: 0;
+}
+
+#inspect-results {
+  margin-top: 1.5rem;
+}
+
 /* --- Category Tabs --- */
 
 .category-tabs {


### PR DESCRIPTION
## Summary

- Add page-level **Scan/Inspect tabs** to the web UI — the Inspect tab provides stateless inspection of certificates, keys, and CSRs with detailed metadata cards (subject, SANs, key usage, EKU, CA status, fingerprints, SKI/AKI, trust/expiry)
- Add **`certkitInspect` WASM function** for browser-based inspection without accumulating into the global MemStore
- Add **`FormatDN`** to render `emailAddress` OID (`1.2.840.113549.1.9.1`) as a human-readable label instead of raw hex in distinguished names
- Add **CSR extension parsing** — `FormatKeyUsageBitString`, `FormatEKUOIDs`, and `parseBasicConstraintsCA` extract Key Usage, EKU, and Basic Constraints from raw ASN.1 extension bytes (Go's `x509.CertificateRequest` doesn't parse these into typed fields)
- Add **`ParseOtherNameSANs`** to extract OtherName (UPN, XMPP, SRV), DirectoryName, and RegisteredID SANs that Go's `x509` package silently drops
- Add **AIA resolution to inspect** (both CLI and WASM) — automatically fetches missing intermediate certificates before trust annotation, so a lone leaf cert shows `Trusted: yes` when the chain resolves

## Test plan

- [ ] `go test -race ./...` passes
- [ ] `golangci-lint run` clean
- [ ] `GOOS=js GOARCH=wasm go vet ./cmd/wasm/` and build pass
- [ ] `cd web && npm test` passes
- [ ] Manual: build WASM, serve locally, verify Scan tab works as before
- [ ] Manual: switch to Inspect tab, paste a PEM leaf cert, verify AIA fetches intermediates and shows Trusted: yes
- [ ] Manual: paste a CSR, verify Key Usage/EKU/CA/SKI display
- [ ] CLI: `certkit inspect cert.pem` on a leaf cert shows fetched intermediates with Trusted: yes
- [ ] CLI: `certkit inspect file.csr` shows emailAddress, Key Usage, EKU, SKI

🤖 Generated with [Claude Code](https://claude.com/claude-code)