### PR TITLE
chore: schedule dependabot updates weekly on Monday UTC

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,9 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      timezone: "Etc/UTC"
     groups:
       actions:
         patterns: ["*"]
@@ -13,13 +15,17 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      timezone: "Etc/UTC"
     commit-message:
       prefix: "build(deps)"
 
   - package-ecosystem: "npm"
     directory: "/web"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "monday"
+      timezone: "Etc/UTC"
     commit-message:
       prefix: "build(deps)"


### PR DESCRIPTION
## Summary
- Change all three dependabot ecosystems (github-actions, gomod, npm) from daily to weekly on Monday, UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)