### PR TITLE
docs: update EXAMPLES.md and README.md for all current commands

### DIFF
--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -2,22 +2,70 @@
 
 A practical guide to common certificate tasks. No prior TLS/SSL knowledge required.
 
+## Table of Contents
+
+- [Quick Glossary](#quick-glossary)
+- [Inspecting](#inspecting)
+  - [What's in this certificate file?](#whats-in-this-certificate-file)
+  - [Inspecting keys and CSRs](#inspecting-keys-and-csrs)
+- [Verifying](#verifying)
+  - [Is my certificate about to expire?](#is-my-certificate-about-to-expire)
+  - [Does my key match my certificate?](#does-my-key-match-my-certificate)
+  - [Is my certificate chain valid?](#is-my-certificate-chain-valid)
+  - [Diagnosing chain failures](#diagnosing-chain-failures)
+- [Connecting](#connecting)
+  - [Test a TLS connection](#test-a-tls-connection)
+  - [Check a non-standard port](#check-a-non-standard-port)
+- [Bundling](#bundling)
+  - [Build a full chain from a leaf cert](#build-a-full-chain-from-a-leaf-cert)
+  - [Extract PEM from a PKCS#12 file](#extract-pem-from-a-pkcs12-file)
+  - [Create a PKCS#12 from PEM files](#create-a-pkcs12-from-pem-files)
+- [Converting](#converting)
+  - [Convert between formats](#convert-between-formats)
+  - [Convert PKCS#12 to JKS](#convert-pkcs12-to-jks)
+- [Scanning](#scanning)
+  - [Survey a directory of certs](#survey-a-directory-of-certs)
+  - [Dump all certs or keys to a single file](#dump-all-certs-or-keys-to-a-single-file)
+  - [Organize certs into named bundles](#organize-certs-into-named-bundles)
+- [Generating Keys and CSRs](#generating-keys-and-csrs)
+  - [Generate a new key pair](#generate-a-new-key-pair)
+  - [Renew a certificate](#renew-a-certificate)
+- [Signing](#signing)
+  - [Create a self-signed CA](#create-a-self-signed-ca)
+  - [Sign a CSR with your CA](#sign-a-csr-with-your-ca)
+- [Revocation Checking](#revocation-checking)
+  - [Check OCSP status](#check-ocsp-status)
+  - [Inspect a CRL](#inspect-a-crl)
+- [Common Workflows](#common-workflows)
+  - [Password-protected files](#password-protected-files)
+  - [Reading from stdin](#reading-from-stdin)
+  - [Working with expired certificates](#working-with-expired-certificates)
+  - [Scripting and CI/CD](#scripting-and-cicd)
+  - [Verbose output](#verbose-output)
+  - [Debug logging](#debug-logging)
+
 ## Quick Glossary
 
-| Term | What it is |
-|---|---|
-| **Certificate** (cert) | A file that proves a server's identity. Contains a public key, domain name(s), expiry date, and a signature from a trusted authority. Usually a `.pem`, `.crt`, or `.cer` file. |
-| **Private key** | The secret half of a key pair. Whoever has this can prove they own the certificate. Usually a `.key` or `.pem` file. **Keep this secret.** |
-| **Certificate chain** | A cert doesn't work alone. It's signed by an intermediate CA, which is signed by a root CA. The chain is: your cert + intermediates + root. Servers need to send the full chain (minus the root) to clients. |
-| **CSR** (Certificate Signing Request) | A file you send to a Certificate Authority (like Let's Encrypt, DigiCert) to request a new certificate. Contains your public key and the domain names you want on the cert. |
-| **PKCS#12** (`.p12`, `.pfx`) | A single file containing a cert + key + chain, often password-protected. Common in Windows and Java environments. |
-| **JKS** (`.jks`) | Java KeyStore. Similar to PKCS#12 but Java-specific. |
-| **PEM** | The most common text format for certs and keys. Looks like `-----BEGIN CERTIFICATE-----` followed by base64 text. |
-| **SAN** (Subject Alternative Name) | The domain names a certificate covers. A single cert can cover `example.com`, `www.example.com`, `api.example.com`, etc. |
+| Term                                          | What it is                                                                                                                                                                                                   |
+| --------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Certificate** (cert)                        | A file that proves a server's identity. Contains a public key, domain name(s), expiry date, and a signature from a trusted authority. Usually a `.pem`, `.crt`, or `.cer` file.                              |
+| **Private key**                               | The secret half of a key pair. Whoever has this can prove they own the certificate. Usually a `.key` or `.pem` file. **Keep this secret.**                                                                   |
+| **Certificate chain**                         | A cert doesn't work alone. It's signed by an intermediate CA, which is signed by a root CA. The chain is: your cert + intermediates + root. Servers need to send the full chain (minus the root) to clients. |
+| **CSR** (Certificate Signing Request)         | A file you send to a Certificate Authority (like Let's Encrypt, DigiCert) to request a new certificate. Contains your public key and the domain names you want on the cert.                                  |
+| **CRL** (Certificate Revocation List)         | A list published by a CA of certificates it has revoked before their expiry date.                                                                                                                            |
+| **OCSP** (Online Certificate Status Protocol) | A real-time protocol for checking whether a certificate has been revoked, without downloading a full CRL.                                                                                                    |
+| **PKCS#12** (`.p12`, `.pfx`)                  | A single file containing a cert + key + chain, often password-protected. Common in Windows and Java environments.                                                                                            |
+| **JKS** (`.jks`)                              | Java KeyStore. Similar to PKCS#12 but Java-specific.                                                                                                                                                         |
+| **PEM**                                       | The most common text format for certs and keys. Looks like `-----BEGIN CERTIFICATE-----` followed by base64 text.                                                                                            |
+| **DER**                                       | Binary encoding of a certificate or key. Same data as PEM but without the base64 text wrapping.                                                                                                              |
+| **SAN** (Subject Alternative Name)            | The domain names a certificate covers. A single cert can cover `example.com`, `www.example.com`, `api.example.com`, etc.                                                                                     |
+| **AIA** (Authority Information Access)        | A certificate extension containing URLs where the issuer's certificate or OCSP responder can be found. certkit uses these to fetch missing intermediates automatically.                                      |
 
 ---
 
-## "What's in this certificate file?"
+## Inspecting
+
+### What's in this certificate file?
 
 You received a `.pem` or `.crt` file and want to know what's in it.
 
@@ -25,7 +73,7 @@ You received a `.pem` or `.crt` file and want to know what's in it.
 certkit inspect cert.pem
 ```
 
-This shows the subject (who it belongs to), issuer (who signed it), validity dates, SANs (domain names), key type, fingerprints, and more.
+This shows the subject (who it belongs to), issuer (who signed it), validity dates, SANs (domain names), key type, fingerprints, trust status, and more. Missing intermediates are automatically fetched via AIA.
 
 For machine-readable output:
 
@@ -33,7 +81,9 @@ For machine-readable output:
 certkit inspect cert.pem --format json
 ```
 
-Works with keys and CSRs too:
+### Inspecting keys and CSRs
+
+Works with private keys and CSRs too:
 
 ```sh
 certkit inspect key.pem
@@ -42,7 +92,9 @@ certkit inspect request.csr
 
 ---
 
-## "Is my certificate about to expire?"
+## Verifying
+
+### Is my certificate about to expire?
 
 Check if a cert expires within the next 30 days:
 
@@ -56,11 +108,9 @@ Check 90 days out (useful for planning renewals):
 certkit verify cert.pem --expiry 90d
 ```
 
-If the cert will expire within that window, certkit exits with an error. This makes it easy to use in scripts or CI/CD pipelines.
+If the cert will expire within that window, certkit exits with code 2. This makes it easy to use in scripts or CI/CD pipelines.
 
----
-
-## "Does my key match my certificate?"
+### Does my key match my certificate?
 
 You have a cert and a key and want to make sure they go together. Mismatched pairs are a common cause of TLS errors.
 
@@ -68,11 +118,9 @@ You have a cert and a key and want to make sure they go together. Mismatched pai
 certkit verify cert.pem --key key.pem
 ```
 
-If they match, you'll see a success message. If not, you'll see an error.
+If they match, you'll see a success message. If not, certkit exits with code 2.
 
----
-
-## "Is my certificate chain valid?"
+### Is my certificate chain valid?
 
 Chain verification happens automatically -- certkit always checks that a cert chains up to a trusted root CA:
 
@@ -98,9 +146,53 @@ For machine-readable output:
 certkit verify cert.pem --format json
 ```
 
+### Diagnosing chain failures
+
+When chain verification fails, use `--diagnose` to understand why:
+
+```sh
+certkit verify cert.pem --diagnose
+```
+
+This shows detailed reasons for the failure -- missing intermediates, expired CAs, untrusted roots, etc.
+
 ---
 
-## "I have a leaf cert and need the full chain"
+## Connecting
+
+### Test a TLS connection
+
+Connect to a server and see its certificate chain, negotiated protocol, and cipher suite:
+
+```sh
+certkit connect example.com
+```
+
+certkit shows the full chain with trust status, client auth requirements, and ALPN protocol. Missing intermediates are fetched via AIA automatically.
+
+For machine-readable output:
+
+```sh
+certkit connect example.com --format json
+```
+
+### Check a non-standard port
+
+```sh
+certkit connect example.com:8443
+```
+
+Override the SNI hostname if the server expects a different name:
+
+```sh
+certkit connect 10.0.0.1:443 --servername example.com
+```
+
+---
+
+## Bundling
+
+### Build a full chain from a leaf cert
 
 Your CA gave you a leaf certificate but you need the full chain for your web server (nginx, Apache, HAProxy, etc.).
 
@@ -117,9 +209,7 @@ certkit bundle cert.pem --format fullchain -o fullchain.pem
 
 certkit automatically fetches missing intermediate certificates from the internet using AIA (Authority Information Access) URLs embedded in the cert.
 
----
-
-## "I need to convert a PKCS#12 (.p12/.pfx) to PEM"
+### Extract PEM from a PKCS#12 file
 
 You got a `.p12` file from someone (common in Windows/Java shops) and need plain PEM files.
 
@@ -133,9 +223,7 @@ certkit bundle server.p12 -p "the-password" -o chain.pem
 
 The key is embedded in the `.p12`, so certkit automatically extracts it and uses it to identify the leaf cert.
 
----
-
-## "I need to create a PKCS#12 from PEM files"
+### Create a PKCS#12 from PEM files
 
 Going the other direction -- you have PEM files and need a `.p12` for a Java app or Windows server.
 
@@ -151,7 +239,44 @@ certkit bundle cert.pem --key key.pem --format jks -o keystore.jks
 
 ---
 
-## "I have a directory full of certs and want to understand what's there"
+## Converting
+
+### Convert between formats
+
+Convert certificates and keys between PEM, DER, PKCS#12, JKS, and PKCS#7:
+
+```sh
+# DER to PEM
+certkit convert cert.der --to pem
+
+# PEM to DER
+certkit convert cert.pem --to der -o cert.der
+
+# PEM cert + key to PKCS#12
+certkit convert cert.pem --key key.pem --to p12 -o bundle.p12
+
+# PKCS#12 to PEM
+certkit convert bundle.p12 --to pem
+
+# PEM to PKCS#7
+certkit convert cert.pem --to p7b -o certs.p7b
+```
+
+Input format is auto-detected. PEM output goes to stdout; binary formats (DER, P12, JKS, P7B) require `-o`.
+
+### Convert PKCS#12 to JKS
+
+```sh
+certkit convert bundle.p12 --to jks -o keystore.jks
+```
+
+Multiple key/cert pairs in the input produce multiple aliases in the JKS keystore.
+
+---
+
+## Scanning
+
+### Survey a directory of certs
 
 Scan a directory to get a summary of everything found:
 
@@ -165,7 +290,7 @@ Output looks like:
 Found 12 certificate(s) and 3 key(s)
   Roots:         2
   Intermediates: 4
-  Leaves:        6
+  Leaves:        6 (2 expired, 1 untrusted)
   Key-cert pairs: 3
 ```
 
@@ -177,9 +302,19 @@ For machine-readable output:
 certkit scan /path/to/certs/ --format json
 ```
 
----
+Save scan results to a SQLite database for later analysis:
 
-## "I want to extract all certs or keys from a directory into one file"
+```sh
+certkit scan /path/to/certs/ --save-db inventory.db
+```
+
+Resume from a previous scan:
+
+```sh
+certkit scan /path/to/new-certs/ --load-db inventory.db --save-db inventory.db
+```
+
+### Dump all certs or keys to a single file
 
 Dump every discovered certificate into a single PEM file:
 
@@ -201,9 +336,7 @@ Both flags can be used together:
 certkit scan /path/to/certs/ --dump-certs certs.pem --dump-keys keys.pem
 ```
 
----
-
-## "I need to organize certs into named bundles for deployment"
+### Organize certs into named bundles
 
 For when you manage multiple domains and want each one exported as a clean set of files.
 
@@ -231,7 +364,9 @@ This creates a directory per bundle with every format you might need: PEM (leaf,
 
 ---
 
-## "I need to generate a new key pair"
+## Generating Keys and CSRs
+
+### Generate a new key pair
 
 Generate an ECDSA key (recommended, fast and secure):
 
@@ -239,7 +374,7 @@ Generate an ECDSA key (recommended, fast and secure):
 certkit keygen
 ```
 
-This prints the private key, public key, and (if requested) CSR to stdout in PEM format. Redirect to save:
+This prints the private key and public key to stdout in PEM format. Redirect to save:
 
 ```sh
 certkit keygen > key.pem
@@ -265,9 +400,7 @@ certkit keygen -o ./keys
 
 This creates `key.pem`, `pub.pem`, and `csr.pem` (if a CN is provided) in the specified directory.
 
----
-
-## "I need to renew a certificate"
+### Renew a certificate
 
 You have an existing cert and need to create a CSR to request a renewal from your CA. This copies the subject and SANs from the old cert:
 
@@ -291,7 +424,105 @@ certkit csr --cert existing-cert.pem -o ./out
 
 ---
 
-## "I have password-protected files"
+## Signing
+
+### Create a self-signed CA
+
+Generate a self-signed root CA certificate for internal use or testing:
+
+```sh
+certkit sign self-signed --cn "My Root CA"
+```
+
+This generates a new EC P-256 key and prints both the certificate and key to stdout. Customize the validity period and save to a file:
+
+```sh
+certkit sign self-signed --cn "My Root CA" --days 3650 -o ca.pem
+```
+
+Create a non-CA leaf certificate (e.g., for testing):
+
+```sh
+certkit sign self-signed --cn "test.local" --is-ca=false
+```
+
+Use an existing key instead of generating one:
+
+```sh
+certkit sign self-signed --cn "My Root CA" --key existing-key.pem
+```
+
+### Sign a CSR with your CA
+
+Issue a certificate by signing a CSR with your CA key:
+
+```sh
+certkit sign csr request.csr --ca ca.pem --ca-key ca-key.pem
+```
+
+SANs from the CSR are copied to the issued certificate by default. Customize the validity:
+
+```sh
+certkit sign csr request.csr --ca ca.pem --ca-key ca-key.pem --days 90 -o cert.pem
+```
+
+---
+
+## Revocation Checking
+
+### Check OCSP status
+
+Check whether a certificate has been revoked via OCSP:
+
+```sh
+certkit ocsp cert.pem --issuer issuer.pem
+```
+
+The OCSP responder URL is read from the certificate's AIA extension. If the input is a PKCS#12 or contains the full chain, the issuer is resolved automatically:
+
+```sh
+certkit ocsp bundle.p12
+```
+
+For machine-readable output:
+
+```sh
+certkit ocsp cert.pem --issuer issuer.pem --format json
+```
+
+certkit exits with code 2 if the certificate is revoked.
+
+### Inspect a CRL
+
+Parse a Certificate Revocation List from a local file or URL:
+
+```sh
+# Local file (PEM or DER)
+certkit crl revoked.crl
+
+# Download from a URL
+certkit crl http://crl.example.com/ca.crl
+```
+
+Check whether a specific certificate appears in the CRL:
+
+```sh
+certkit crl revoked.crl --check cert.pem
+```
+
+certkit exits with code 2 if the certificate is found in the CRL.
+
+For machine-readable output:
+
+```sh
+certkit crl revoked.crl --format json
+```
+
+---
+
+## Common Workflows
+
+### Password-protected files
 
 For encrypted private keys, PKCS#12, or JKS files, pass passwords with `-p`:
 
@@ -308,9 +539,7 @@ certkit scan /path/to/certs/ --password-file passwords.txt
 
 certkit always tries empty string, `password`, `changeit`, and `keypassword` automatically -- those cover most default passwords.
 
----
-
-## "I want to read a cert from stdin"
+### Reading from stdin
 
 Pipe certificate data directly:
 
@@ -320,9 +549,7 @@ cat cert.pem | certkit scan -
 
 Useful in scripts or when fetching certs from other tools.
 
----
-
-## "I need to work with expired certificates"
+### Working with expired certificates
 
 certkit always reads and parses expired certificates -- they're never silently dropped. However, expired certificates are excluded from output by default (scan summaries, bundle exports). Use `--allow-expired` to include them:
 
@@ -333,19 +560,17 @@ certkit bundle expired-cert.pem --allow-expired --force
 
 Commands that target a specific file (`inspect`, `verify`) always show the certificate regardless of expiry.
 
----
-
-## "I want to use certkit in a script or CI/CD pipeline"
+### Scripting and CI/CD
 
 certkit uses meaningful exit codes:
 
-| Exit code | Meaning |
-|---|---|
-| **0** | Success |
-| **1** | General error (bad input, missing file, etc.) |
-| **2** | Validation failure (chain invalid, key mismatch, expired) |
+| Exit code | Meaning                                                            |
+| --------- | ------------------------------------------------------------------ |
+| **0**     | Success                                                            |
+| **1**     | General error (bad input, missing file, etc.)                      |
+| **2**     | Validation failure (chain invalid, key mismatch, expired, revoked) |
 
-Use `--format json` on `inspect`, `verify`, and `scan` for machine-readable output. Data always goes to stdout, warnings and progress to stderr, so piping works cleanly:
+Use `--format json` on any command for machine-readable output. Data always goes to stdout, warnings and progress to stderr, so piping works cleanly:
 
 ```sh
 # Check cert in CI -- fails with exit code 2 if expiring within 30 days
@@ -356,11 +581,21 @@ certkit inspect cert.pem --format json | jq '.subject'
 
 # Verify and capture result
 certkit verify cert.pem --format json > result.json
+
+# Check revocation in a pipeline
+certkit ocsp cert.pem --issuer issuer.pem --format json | jq '.status'
 ```
 
----
+### Verbose output
 
-## "I'm debugging and want more detail"
+Add `--verbose` to see extended details like serial number, key algorithm and size, signature algorithm, key usages, and extended key usages:
+
+```sh
+certkit verify cert.pem --verbose
+certkit connect example.com --verbose
+```
+
+### Debug logging
 
 Turn on debug logging to see exactly what certkit is doing:
 

--- a/README.md
+++ b/README.md
@@ -8,10 +8,13 @@ A Swiss Army knife for TLS/SSL certificates. Inspect, verify, bundle, scan, and 
 
 - **Inspect** any certificate, key, or CSR and see exactly what's in it
 - **Verify** that a cert chains to a trusted root, matches its key, and isn't about to expire
+- **Connect** to a TLS server and display its certificate chain, cipher suite, and ALPN
 - **Bundle** a leaf cert into a full chain for your web server (nginx, Apache, HAProxy, etc.)
+- **Convert** between PEM, DER, PKCS#12, JKS, PKCS#7, and Kubernetes Secrets
+- **Sign** certificates -- self-signed CAs or issue certs from CSRs
 - **Scan** a directory full of certs and keys to understand what you have
 - **Generate** new key pairs and CSRs for certificate renewals
-- **Convert** between formats -- PEM, PKCS#12, JKS, PKCS#7, DER, Kubernetes Secrets
+- **Check revocation** via OCSP or CRL
 
 Works with every common format out of the box. No OpenSSL gymnastics required.
 
@@ -87,14 +90,20 @@ See [EXAMPLES.md](EXAMPLES.md) for a complete walkthrough of every command with 
 
 ## Commands
 
-| Command | What it does |
-|---|---|
-| `certkit inspect <file>` | Show what's in a cert, key, or CSR |
-| `certkit verify <file>` | Check chain, key match, and expiry |
-| `certkit bundle <file>` | Build a certificate chain from a leaf cert |
-| `certkit scan <path>` | Scan a directory and catalog everything found |
-| `certkit keygen` | Generate a new key pair (and optionally a CSR) |
-| `certkit csr` | Generate a CSR from a template, cert, or existing CSR |
+| Command                     | What it does                                            |
+| --------------------------- | ------------------------------------------------------- |
+| `certkit inspect <file>`    | Show what's in a cert, key, or CSR                      |
+| `certkit verify <file>`     | Check chain, key match, and expiry                      |
+| `certkit connect <host>`    | Test a TLS connection and display the certificate chain |
+| `certkit bundle <file>`     | Build a certificate chain from a leaf cert              |
+| `certkit convert <file>`    | Convert between PEM, DER, PKCS#12, JKS, and PKCS#7      |
+| `certkit sign self-signed`  | Create a self-signed certificate                        |
+| `certkit sign csr <file>`   | Sign a CSR with a CA certificate and key                |
+| `certkit scan <path>`       | Scan a directory and catalog everything found           |
+| `certkit keygen`            | Generate a new key pair (and optionally a CSR)          |
+| `certkit csr`               | Generate a CSR from a template, cert, or existing CSR   |
+| `certkit ocsp <file>`       | Check certificate revocation status via OCSP            |
+| `certkit crl <file-or-url>` | Parse a CRL and check for revoked certificates          |
 
 ## License
 
@@ -106,90 +115,149 @@ See [EXAMPLES.md](EXAMPLES.md) for a complete walkthrough of every command with 
 
 ### Global Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--log-level`, `-l` | `info` | Log level: `debug`, `info`, `warn`, `error` |
-| `--passwords`, `-p` | | Comma-separated passwords for encrypted keys |
-| `--password-file` | | File containing passwords, one per line |
-| `--allow-expired` | `false` | Include expired certificates |
+| Flag                | Default | Description                                                                        |
+| ------------------- | ------- | ---------------------------------------------------------------------------------- |
+| `--log-level`, `-l` | `info`  | Log level: `debug`, `info`, `warn`, `error`                                        |
+| `--passwords`, `-p` |         | Comma-separated passwords for encrypted keys                                       |
+| `--password-file`   |         | File containing passwords, one per line                                            |
+| `--allow-expired`   | `false` | Include expired certificates                                                       |
+| `--verbose`, `-v`   | `false` | Extended details in output (serial, key info, signature algorithm, key usage, EKU) |
 
 Common passwords (`""`, `"password"`, `"changeit"`, `"keypassword"`) are always tried automatically.
 
 ### Inspect Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--format` | `text` | Output format: `text`, `json` |
+| Flag       | Default | Description                   |
+| ---------- | ------- | ----------------------------- |
+| `--format` | `text`  | Output format: `text`, `json` |
 
 ### Verify Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--key` | | Private key file to check against the certificate |
-| `--expiry`, `-e` | | Check if cert expires within duration (e.g., `30d`, `720h`) |
-| `--trust-store` | `mozilla` | Trust store: `system`, `mozilla` |
-| `--format` | `text` | Output format: `text`, `json` |
+| Flag             | Default   | Description                                                 |
+| ---------------- | --------- | ----------------------------------------------------------- |
+| `--key`          |           | Private key file to check against the certificate           |
+| `--expiry`, `-e` |           | Check if cert expires within duration (e.g., `30d`, `720h`) |
+| `--trust-store`  | `mozilla` | Trust store: `system`, `mozilla`                            |
+| `--format`       | `text`    | Output format: `text`, `json`                               |
+| `--diagnose`     | `false`   | Show diagnostics when chain verification fails              |
 
 Chain verification is always performed. When the input contains an embedded private key (PKCS#12, JKS), key match is checked automatically.
 
+### Connect Flags
+
+| Flag           | Default | Description                              |
+| -------------- | ------- | ---------------------------------------- |
+| `--servername` |         | Override SNI hostname (defaults to host) |
+| `--format`     | `text`  | Output format: `text`, `json`            |
+
+Port defaults to 443 if not specified. Use `--verbose` for extended details (serial, key info, signature algorithm, key usage, EKU).
+
 ### Bundle Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--key` | | Private key file (PEM) |
-| `--out-file`, `-o` | *(stdout)* | Output file |
-| `--format` | `pem` | Output format: `pem`, `chain`, `fullchain`, `p12`, `jks` |
-| `--force`, `-f` | `false` | Skip chain verification |
-| `--trust-store` | `mozilla` | Trust store: `system`, `mozilla` |
+| Flag               | Default    | Description                                              |
+| ------------------ | ---------- | -------------------------------------------------------- |
+| `--key`            |            | Private key file (PEM)                                   |
+| `--out-file`, `-o` | _(stdout)_ | Output file                                              |
+| `--format`         | `pem`      | Output format: `pem`, `chain`, `fullchain`, `p12`, `jks` |
+| `--force`, `-f`    | `false`    | Skip chain verification                                  |
+| `--trust-store`    | `mozilla`  | Trust store: `system`, `mozilla`                         |
+
+### Convert Flags
+
+| Flag               | Default            | Description                                      |
+| ------------------ | ------------------ | ------------------------------------------------ |
+| `--to`             | _(required)_       | Output format: `pem`, `der`, `p12`, `jks`, `p7b` |
+| `--key`            |                    | Private key file (PEM)                           |
+| `--out-file`, `-o` | _(stdout for PEM)_ | Output file (required for binary formats)        |
+
+Input format is auto-detected.
+
+### Sign Self-Signed Flags
+
+| Flag               | Default      | Description                                               |
+| ------------------ | ------------ | --------------------------------------------------------- |
+| `--cn`             | _(required)_ | Common Name for the certificate                           |
+| `--key`            |              | Existing private key file (generates EC P-256 if omitted) |
+| `--days`           | `3650`       | Validity period in days                                   |
+| `--is-ca`          | `true`       | Set CA:TRUE basic constraint                              |
+| `--out-file`, `-o` | _(stdout)_   | Output file                                               |
+
+### Sign CSR Flags
+
+| Flag               | Default      | Description                              |
+| ------------------ | ------------ | ---------------------------------------- |
+| `--ca`             | _(required)_ | CA certificate file (PEM)                |
+| `--ca-key`         | _(required)_ | CA private key file (PEM)                |
+| `--days`           | `365`        | Validity period in days                  |
+| `--copy-sans`      | `true`       | Copy SANs from CSR to issued certificate |
+| `--out-file`, `-o` | _(stdout)_   | Output file                              |
 
 ### Scan Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--bundle-path` | | Export bundles to this directory |
-| `--config`, `-c` | `./bundles.yaml` | Path to bundle config YAML |
-| `--force`, `-f` | `false` | Allow export of untrusted certificate bundles |
-| `--duplicates` | `false` | Export all certificates per bundle, not just the newest |
-| `--dump-keys` | | Dump all discovered keys to a single PEM file |
-| `--dump-certs` | | Dump all discovered certificates to a single PEM file |
-| `--max-file-size` | `10485760` | Skip files larger than this size in bytes (0 to disable) |
-| `--save-db` | | Save the in-memory database to disk after scanning |
-| `--load-db` | | Load an existing database into memory before scanning |
-| `--format` | `text` | Output format: `text`, `json` |
+| Flag              | Default          | Description                                              |
+| ----------------- | ---------------- | -------------------------------------------------------- |
+| `--bundle-path`   |                  | Export bundles to this directory                         |
+| `--config`, `-c`  | `./bundles.yaml` | Path to bundle config YAML                               |
+| `--force`, `-f`   | `false`          | Allow export of untrusted certificate bundles            |
+| `--duplicates`    | `false`          | Export all certificates per bundle, not just the newest  |
+| `--dump-keys`     |                  | Dump all discovered keys to a single PEM file            |
+| `--dump-certs`    |                  | Dump all discovered certificates to a single PEM file    |
+| `--max-file-size` | `10485760`       | Skip files larger than this size in bytes (0 to disable) |
+| `--save-db`       |                  | Save the in-memory database to disk after scanning       |
+| `--load-db`       |                  | Load an existing database into memory before scanning    |
+| `--format`        | `text`           | Output format: `text`, `json`                            |
 
 ### Keygen Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--algorithm`, `-a` | `ecdsa` | Key algorithm: `rsa`, `ecdsa`, `ed25519` |
-| `--bits`, `-b` | `4096` | RSA key size in bits |
-| `--curve` | `P-256` | ECDSA curve: `P-256`, `P-384`, `P-521` |
-| `--out-path`, `-o` | *(stdout)* | Output directory |
-| `--cn` | | Common Name (triggers CSR generation) |
-| `--sans` | | Comma-separated SANs (triggers CSR generation) |
+| Flag                | Default    | Description                                    |
+| ------------------- | ---------- | ---------------------------------------------- |
+| `--algorithm`, `-a` | `ecdsa`    | Key algorithm: `rsa`, `ecdsa`, `ed25519`       |
+| `--bits`, `-b`      | `4096`     | RSA key size in bits                           |
+| `--curve`           | `P-256`    | ECDSA curve: `P-256`, `P-384`, `P-521`         |
+| `--out-path`, `-o`  | _(stdout)_ | Output directory                               |
+| `--cn`              |            | Common Name (triggers CSR generation)          |
+| `--sans`            |            | Comma-separated SANs (triggers CSR generation) |
 
 ### CSR Flags
 
-| Flag | Default | Description |
-|---|---|---|
-| `--template` | | JSON template file for CSR generation |
-| `--cert` | | PEM certificate to use as CSR template |
-| `--from-csr` | | Existing PEM CSR to re-sign with a new key |
-| `--key` | | Existing private key file (PEM); generates new if omitted |
-| `--algorithm`, `-a` | `ecdsa` | Key algorithm for generated keys |
-| `--bits`, `-b` | `4096` | RSA key size in bits |
-| `--curve` | `P-256` | ECDSA curve |
-| `--out-path`, `-o` | *(stdout)* | Output directory |
+| Flag                | Default    | Description                                               |
+| ------------------- | ---------- | --------------------------------------------------------- |
+| `--template`        |            | JSON template file for CSR generation                     |
+| `--cert`            |            | PEM certificate to use as CSR template                    |
+| `--from-csr`        |            | Existing PEM CSR to re-sign with a new key                |
+| `--key`             |            | Existing private key file (PEM); generates new if omitted |
+| `--algorithm`, `-a` | `ecdsa`    | Key algorithm for generated keys                          |
+| `--bits`, `-b`      | `4096`     | RSA key size in bits                                      |
+| `--curve`           | `P-256`    | ECDSA curve                                               |
+| `--out-path`, `-o`  | _(stdout)_ | Output directory                                          |
 
 Exactly one of `--template`, `--cert`, or `--from-csr` is required.
 
+### OCSP Flags
+
+| Flag       | Default | Description                                                        |
+| ---------- | ------- | ------------------------------------------------------------------ |
+| `--issuer` |         | Issuer certificate file (PEM); auto-resolved from input if omitted |
+| `--format` | `text`  | Output format: `text`, `json`                                      |
+
+The OCSP responder URL is read from the certificate's AIA extension.
+
+### CRL Flags
+
+| Flag       | Default | Description                               |
+| ---------- | ------- | ----------------------------------------- |
+| `--check`  |         | Certificate file to check against the CRL |
+| `--format` | `text`  | Output format: `text`, `json`             |
+
+Accepts local files (PEM or DER) or HTTP URLs.
+
 ### Exit Codes
 
-| Code | Meaning |
-|---|---|
-| `0` | Success |
-| `1` | General error (bad input, missing file, etc.) |
-| `2` | Validation failure (chain invalid, key mismatch, expired) |
+| Code | Meaning                                                            |
+| ---- | ------------------------------------------------------------------ |
+| `0`  | Success                                                            |
+| `1`  | General error (bad input, missing file, etc.)                      |
+| `2`  | Validation failure (chain invalid, key mismatch, expired, revoked) |
 
 ### Bundle Configuration
 
@@ -206,14 +274,14 @@ defaultSubject:
 bundles:
   - bundleName: examplecom-tls
     commonNames:
-      - '*.example.com'
+      - "*.example.com"
       - example.com
 
   - bundleName: exampleio-tls
     commonNames:
-      - '*.example.io'
+      - "*.example.io"
       - example.io
-    subject:  # overrides defaultSubject for this bundle
+    subject: # overrides defaultSubject for this bundle
       country: [GB]
       province: [London]
       locality: [London]
@@ -227,20 +295,20 @@ Bundles without an explicit `subject` block inherit from `defaultSubject`. Certi
 
 When running `certkit scan --bundle-path`, each bundle produces the following files under `<dir>/<bundleName>/`:
 
-| File | Contents |
-|---|---|
-| `<cn>.pem` | Leaf certificate |
-| `<cn>.chain.pem` | Leaf + intermediates |
-| `<cn>.fullchain.pem` | Leaf + intermediates + root |
-| `<cn>.intermediates.pem` | Intermediate certificates |
-| `<cn>.root.pem` | Root certificate |
-| `<cn>.key` | Private key (PEM, mode 0600) |
-| `<cn>.p12` | PKCS#12 archive (default password: `changeit`, override via `--passwords`, mode 0600) |
-| `<cn>.k8s.yaml` | Kubernetes `kubernetes.io/tls` Secret (mode 0600) |
-| `<cn>.json` | Certificate metadata |
-| `<cn>.yaml` | Certificate and key metadata |
-| `<cn>.csr` | Certificate Signing Request |
-| `<cn>.csr.json` | CSR details (subject, SANs, key algorithm) |
+| File                     | Contents                                                                              |
+| ------------------------ | ------------------------------------------------------------------------------------- |
+| `<cn>.pem`               | Leaf certificate                                                                      |
+| `<cn>.chain.pem`         | Leaf + intermediates                                                                  |
+| `<cn>.fullchain.pem`     | Leaf + intermediates + root                                                           |
+| `<cn>.intermediates.pem` | Intermediate certificates                                                             |
+| `<cn>.root.pem`          | Root certificate                                                                      |
+| `<cn>.key`               | Private key (PEM, mode 0600)                                                          |
+| `<cn>.p12`               | PKCS#12 archive (default password: `changeit`, override via `--passwords`, mode 0600) |
+| `<cn>.k8s.yaml`          | Kubernetes `kubernetes.io/tls` Secret (mode 0600)                                     |
+| `<cn>.json`              | Certificate metadata                                                                  |
+| `<cn>.yaml`              | Certificate and key metadata                                                          |
+| `<cn>.csr`               | Certificate Signing Request                                                           |
+| `<cn>.csr.json`          | CSR details (subject, SANs, key algorithm)                                            |
 
 Wildcard characters in the CN are replaced with `_` in filenames (e.g., `*.example.com` becomes `_.example.com`). The `.intermediates.pem` and `.root.pem` files are only created when those certificates exist in the chain.
 
@@ -276,6 +344,16 @@ rsaKey, _ := certkit.GenerateRSAKey(4096)
 
 // Generate CSRs
 csrPEM, keyPEM, _ := certkit.GenerateCSR(leaf, nil) // auto-generates EC P-256 key
+
+// Sign certificates
+selfSigned, _ := certkit.CreateSelfSigned(certkit.SelfSignedInput{Signer: caKey, Subject: pkix.Name{CommonName: "My CA"}, IsCA: true})
+issued, _ := certkit.SignCSR(certkit.SignCSRInput{CSR: csr, CACert: caCert, CAKey: caKey, Days: 365})
+
+// TLS connection probing
+result, _ := certkit.ConnectTLS(ctx, certkit.ConnectTLSInput{Host: "example.com"})
+
+// Revocation checking
+ocspResp, _ := certkit.CheckOCSP(ctx, certkit.CheckOCSPInput{Cert: cert, Issuer: issuer})
 
 // PKCS operations
 p12, _ := certkit.EncodePKCS12(key, leaf, intermediates, "password")


### PR DESCRIPTION
## Summary

- Rewrite EXAMPLES.md with a proper table of contents and organized sections covering all 11 commands
- Add missing examples for `convert`, `sign`, `connect`, `ocsp`, and `crl` commands (added in #75)
- Add documentation for `--diagnose`, `--verbose`, AIA resolution, and `--save-db`/`--load-db`
- Update README.md commands table, feature list, reference flag tables, and library code snippet to match

## Test plan

- [x] `markdownlint` passes on both files
- [x] `prettier` formatting applied
- [ ] Visual review of rendered markdown on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)