### PR TITLE
chore: release v0.8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.2] - 2026-03-02
+
 ### Added
 
 - Add JSON summary output for `scan --bundle-path` when `--json` or `--format json` is selected, including `bundle_path` ([#87])
@@ -874,7 +876,8 @@ Initial release.
 - PKCS#12, PKCS#7, and JKS encode/decode support
 - Homebrew distribution via GoReleaser
 
-[Unreleased]: https://github.com/sensiblebit/certkit/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/sensiblebit/certkit/compare/v0.8.2...HEAD
+[0.8.2]: https://github.com/sensiblebit/certkit/compare/v0.8.1...v0.8.2
 [0.8.1]: https://github.com/sensiblebit/certkit/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/sensiblebit/certkit/compare/v0.7.7...v0.8.0
 [0.7.7]: https://github.com/sensiblebit/certkit/compare/v0.7.6...v0.7.7


### PR DESCRIPTION
## Summary
- prepare patch release `v0.8.2` by cutting the current Unreleased changelog into a dated release section
- add a fresh empty `Unreleased` section for follow-up work
- update changelog comparison links for `v0.8.2`