### PR TITLE
chore(release): cut v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1063,6 +1063,7 @@ Initial release.
 [#127]: https://github.com/sensiblebit/certkit/pull/127
 [#128]: https://github.com/sensiblebit/certkit/pull/128
 [#129]: https://github.com/sensiblebit/certkit/pull/129
+[#132]: https://github.com/sensiblebit/certkit/pull/132
 [#131]: https://github.com/sensiblebit/certkit/pull/131
 [#73]: https://github.com/sensiblebit/certkit/pull/73
 [#64]: https://github.com/sensiblebit/certkit/pull/64


### PR DESCRIPTION
## Summary
- cut the `0.8.3` changelog release section dated 2026-03-09
- reset `Unreleased` and advance the compare links
- add the missing `[#132]` changelog link definition

## Testing
- pre-commit run --all-files
- pre-commit run --files CHANGELOG.md