### PR TITLE
perf: parallelize trust verification and default to mozilla root store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Breaking:** Default `TrustStore` in `DefaultOptions()` changed from `"system"` to `"mozilla"` — pure-Go Mozilla root verification is used by default instead of macOS `SecTrustEvaluateWithError` syscalls, eliminating multi-minute hangs on large certificate stores
+- Parallelize trust verification in scan summary, dump-certs, and AIA resolution — mozilla checks run concurrently, system checks only run for certs mozilla didn't trust
+- Add `TrustStore` label to `VerifyChainTrustInput` and debug-log every trust verification call with subject, store, and result
 - Normalize all exported private key PEM output (`.key`, K8s `tls.key`, YAML `key`) to PKCS#8 (`PRIVATE KEY`) regardless of input format ([#167])
 - Bundle export warns when Kubernetes TLS secret contains an unencrypted private key alongside encrypted outputs ([#167])
 - Use browser Web Crypto API for PBKDF2 key derivation in WASM builds to avoid blocking the main thread during encrypted key export ([#167])

--- a/README.md
+++ b/README.md
@@ -403,9 +403,9 @@ if certkit.CertExpiresWithin(cert, 30*24*time.Hour) {
     // cert expires within 30 days
 }
 
-// Build verified chains (library defaults to system trust store)
+// Build verified chains (library defaults to mozilla trust store)
 opts := certkit.DefaultOptions()
-opts.TrustStore = "mozilla" // override the default system trust store if needed
+opts.TrustStore = "system" // override the default mozilla trust store if needed
 bundle, _ := certkit.Bundle(ctx, certkit.BundleInput{Leaf: leaf, Options: opts})
 
 // Generate keys

--- a/bundle.go
+++ b/bundle.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"runtime"
 	"slices"
 	"strings"
 	"sync"
@@ -368,6 +369,9 @@ type CheckTrustAnchorsResult struct {
 // invalid at the leaf's issuance time. This is an uncommon edge case in
 // practice (intermediates outlive the leaves they sign).
 func VerifyChainTrust(input VerifyChainTrustInput) bool {
+	if input.Cert == nil {
+		return false
+	}
 	store := input.TrustStore
 	if store == "" {
 		store = "unknown"
@@ -746,14 +750,18 @@ func countAIAUnresolvedIssuers(certs []*x509.Certificate, roots *x509.CertPool) 
 		}
 	}
 
-	// Verify trust for all candidates concurrently.
+	// Verify trust for all candidates concurrently. Bounded to NumCPU
+	// because system trust checks on macOS block in SecTrustEvaluateWithError.
 	trusted := make([]bool, len(certs))
 	if len(candidates) > 0 {
 		var wg sync.WaitGroup
-		wg.Add(len(candidates))
+		sem := make(chan struct{}, runtime.NumCPU())
 		for _, c := range candidates {
+			wg.Add(1)
+			sem <- struct{}{}
 			go func(idx int, cert *x509.Certificate) {
 				defer wg.Done()
+				defer func() { <-sem }()
 				trusted[idx] = VerifyChainTrust(VerifyChainTrustInput{
 					Cert:          cert,
 					Roots:         roots,

--- a/bundle.go
+++ b/bundle.go
@@ -337,6 +337,8 @@ type VerifyChainTrustInput struct {
 	Cert          *x509.Certificate
 	Roots         *x509.CertPool
 	Intermediates *x509.CertPool
+	// TrustStore is an optional label for debug logging (e.g. "mozilla", "system").
+	TrustStore string
 }
 
 // CheckTrustAnchorsInput holds parameters for CheckTrustAnchors.
@@ -366,8 +368,15 @@ type CheckTrustAnchorsResult struct {
 // invalid at the leaf's issuance time. This is an uncommon edge case in
 // practice (intermediates outlive the leaves they sign).
 func VerifyChainTrust(input VerifyChainTrustInput) bool {
+	store := input.TrustStore
+	if store == "" {
+		store = "unknown"
+	}
+	slog.Debug("verifying chain trust", "subject", input.Cert.Subject.CommonName, "store", store)
 	chains, err := verifyChainTrustChains(input)
-	return err == nil && len(chains) > 0
+	trusted := err == nil && len(chains) > 0
+	slog.Debug("chain trust result", "subject", input.Cert.Subject.CommonName, "store", store, "trusted", trusted)
+	return trusted
 }
 
 func verifyChainTrustChains(input VerifyChainTrustInput) ([][]*x509.Certificate, error) {
@@ -413,6 +422,7 @@ func CheckTrustAnchors(input CheckTrustAnchorsInput) CheckTrustAnchorsResult {
 		Cert:          input.Cert,
 		Roots:         mozillaPool,
 		Intermediates: input.Intermediates,
+		TrustStore:    "mozilla",
 	}) {
 		result.Anchors = append(result.Anchors, "mozilla")
 	}
@@ -422,6 +432,7 @@ func CheckTrustAnchors(input CheckTrustAnchorsInput) CheckTrustAnchorsResult {
 		Cert:          input.Cert,
 		Roots:         systemPool,
 		Intermediates: input.Intermediates,
+		TrustStore:    "system",
 	}) {
 		result.Anchors = append(result.Anchors, "system")
 	}
@@ -429,6 +440,7 @@ func CheckTrustAnchors(input CheckTrustAnchorsInput) CheckTrustAnchorsResult {
 		Cert:          input.Cert,
 		Roots:         input.FileRoots,
 		Intermediates: input.Intermediates,
+		TrustStore:    "file",
 	}) {
 		result.Anchors = append(result.Anchors, "file")
 	}
@@ -496,7 +508,7 @@ func DefaultOptions() BundleOptions {
 		AIATimeout:       2 * time.Second,
 		AIAMaxDepth:      5,
 		AIAMaxTotalCerts: defaultAIAMaxTotalCerts,
-		TrustStore:       "system",
+		TrustStore:       "mozilla",
 		Verify:           true,
 		MaxIntermediates: defaultBundleMaxIntermediates,
 	}
@@ -705,25 +717,60 @@ func countAIAUnresolvedIssuers(certs []*x509.Certificate, roots *x509.CertPool) 
 		}
 	}
 
-	unresolved := 0
-	for _, cert := range certs {
+	// Identify candidates that need trust verification.
+	type candidate struct {
+		idx  int
+		cert *x509.Certificate
+	}
+	var candidates []candidate
+	skipFlags := make([]bool, len(certs))
+	for i, cert := range certs {
 		if cert == nil {
+			skipFlags[i] = true
 			continue
 		}
 		if len(cert.IssuingCertificateURL) == 0 {
+			skipFlags[i] = true
 			continue
 		}
 		if IsMozillaRoot(cert) {
+			skipFlags[i] = true
 			continue
 		}
 		if bytes.Equal(cert.RawSubject, cert.RawIssuer) {
+			skipFlags[i] = true
 			continue
 		}
-		if roots != nil && VerifyChainTrust(VerifyChainTrustInput{
-			Cert:          cert,
-			Roots:         roots,
-			Intermediates: intermediates,
-		}) {
+		if roots != nil {
+			candidates = append(candidates, candidate{idx: i, cert: cert})
+		}
+	}
+
+	// Verify trust for all candidates concurrently.
+	trusted := make([]bool, len(certs))
+	if len(candidates) > 0 {
+		var wg sync.WaitGroup
+		wg.Add(len(candidates))
+		for _, c := range candidates {
+			go func(idx int, cert *x509.Certificate) {
+				defer wg.Done()
+				trusted[idx] = VerifyChainTrust(VerifyChainTrustInput{
+					Cert:          cert,
+					Roots:         roots,
+					Intermediates: intermediates,
+					TrustStore:    "aia-resolve",
+				})
+			}(c.idx, c.cert)
+		}
+		wg.Wait()
+	}
+
+	unresolved := 0
+	for i, cert := range certs {
+		if skipFlags[i] {
+			continue
+		}
+		if trusted[i] {
 			continue
 		}
 		if hasIssuerInSet(cert, certs) {

--- a/bundle_test.go
+++ b/bundle_test.go
@@ -159,8 +159,8 @@ func TestDefaultOptions(t *testing.T) {
 	if opts.AIAMaxTotalCerts != defaultAIAMaxTotalCerts {
 		t.Fatalf("AIAMaxTotalCerts = %d, want %d", opts.AIAMaxTotalCerts, defaultAIAMaxTotalCerts)
 	}
-	if opts.TrustStore != "system" {
-		t.Fatalf("TrustStore = %q, want system", opts.TrustStore)
+	if opts.TrustStore != "mozilla" {
+		t.Fatalf("TrustStore = %q, want mozilla", opts.TrustStore)
 	}
 	if !opts.Verify {
 		t.Fatal("Verify = false, want true")

--- a/cmd/certkit/scan.go
+++ b/cmd/certkit/scan.go
@@ -14,6 +14,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/sensiblebit/certkit"
@@ -279,10 +280,58 @@ func runScan(cmd *cobra.Command, args []string) error {
 			}
 			intermediatePool := store.IntermediatePool()
 
+			// Pre-compute trust status concurrently. Mozilla checks are pure Go
+			// and fast; system checks hit macOS SecTrust which is slow. Run
+			// mozilla first, then only check system for untrusted remainders.
+			type dumpTrust struct {
+				mozilla bool
+				system  bool
+			}
+			now := time.Now()
+			trustStatus := make([]dumpTrust, len(certs))
+			if !scanForceExport && (trustPools.Mozilla != nil || trustPools.System != nil) {
+				var wg sync.WaitGroup
+				if trustPools.Mozilla != nil {
+					for i, c := range certs {
+						if !allowExpired && now.After(c.Cert.NotAfter) {
+							continue
+						}
+						wg.Add(1)
+						go func(idx int, cert *x509.Certificate) {
+							defer wg.Done()
+							trustStatus[idx].mozilla = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
+								Cert:          cert,
+								Roots:         trustPools.Mozilla,
+								Intermediates: intermediatePool,
+								TrustStore:    "mozilla",
+							})
+						}(i, c.Cert)
+					}
+					wg.Wait()
+				}
+				if trustPools.System != nil {
+					for i, c := range certs {
+						if (!allowExpired && now.After(c.Cert.NotAfter)) || trustStatus[i].mozilla {
+							continue
+						}
+						wg.Add(1)
+						go func(idx int, cert *x509.Certificate) {
+							defer wg.Done()
+							trustStatus[idx].system = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
+								Cert:          cert,
+								Roots:         trustPools.System,
+								Intermediates: intermediatePool,
+								TrustStore:    "system",
+							})
+						}(i, c.Cert)
+					}
+					wg.Wait()
+				}
+			}
+
 			var data []byte
 			var count, skipped int
-			now := time.Now()
-			for _, c := range certs {
+			for i, c := range certs {
 				cert := c.Cert
 
 				// Skip expired certificates unless --allow-expired is set
@@ -294,17 +343,7 @@ func runScan(cmd *cobra.Command, args []string) error {
 
 				// Validate chain unless --force is set (uses same logic as summary)
 				if !scanForceExport {
-					mozillaTrusted := trustPools.Mozilla != nil && certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
-						Cert:          cert,
-						Roots:         trustPools.Mozilla,
-						Intermediates: intermediatePool,
-					})
-					systemTrusted := trustPools.System != nil && certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
-						Cert:          cert,
-						Roots:         trustPools.System,
-						Intermediates: intermediatePool,
-					})
-					if !mozillaTrusted && !systemTrusted && (trustPools.Mozilla != nil || trustPools.System != nil) {
+					if !trustStatus[i].mozilla && !trustStatus[i].system && (trustPools.Mozilla != nil || trustPools.System != nil) {
 						slog.Debug("skipping untrusted certificate", "subject", cert.Subject)
 						skipped++
 						continue

--- a/cmd/certkit/scan.go
+++ b/cmd/certkit/scan.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -310,13 +311,16 @@ func runScan(cmd *cobra.Command, args []string) error {
 					wg.Wait()
 				}
 				if trustPools.System != nil {
+					sem := make(chan struct{}, runtime.NumCPU())
 					for i, c := range certs {
 						if (!allowExpired && now.After(c.Cert.NotAfter)) || trustStatus[i].mozilla {
 							continue
 						}
 						wg.Add(1)
+						sem <- struct{}{}
 						go func(idx int, cert *x509.Certificate) {
 							defer wg.Done()
+							defer func() { <-sem }()
 							trustStatus[idx].system = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
 								Cert:          cert,
 								Roots:         trustPools.System,

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -327,7 +327,7 @@ func getState(_ js.Value, _ []js.Value) any {
 		expired := now.After(rec.NotAfter)
 		trusted := false
 		if roots != nil {
-			trusted = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{Cert: rec.Cert, Roots: roots, Intermediates: intermediatePool})
+			trusted = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{Cert: rec.Cert, Roots: roots, Intermediates: intermediatePool, TrustStore: "mozilla"})
 		}
 
 		serial := ""

--- a/internal/certstore/memstore.go
+++ b/internal/certstore/memstore.go
@@ -398,19 +398,58 @@ func (s *MemStore) ScanSummary(input ScanSummaryInput) ScanSummary {
 		}
 	}
 
+	// Pre-compute trust status for all non-expired certs concurrently.
+	// Mozilla checks are pure Go and fast; system checks hit the macOS
+	// Security framework (SecTrustEvaluateWithError) which is slow.
+	// Run mozilla first, then only check system for certs mozilla didn't trust.
+	type trustStatus struct {
+		mozilla bool
+		system  bool
+	}
 	now := time.Now()
-	for _, rec := range certs {
-		expired := now.After(rec.NotAfter)
-		mozillaTrusted := false
-		systemTrusted := false
-		if !expired {
-			if input.MozillaPool != nil {
-				mozillaTrusted = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{Cert: rec.Cert, Roots: input.MozillaPool, Intermediates: intermediatePool})
+	trustResults := make([]trustStatus, len(certs))
+	var wg sync.WaitGroup
+	if input.MozillaPool != nil {
+		for i, rec := range certs {
+			if now.After(rec.NotAfter) {
+				continue
 			}
-			if input.SystemPool != nil {
-				systemTrusted = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{Cert: rec.Cert, Roots: input.SystemPool, Intermediates: intermediatePool})
-			}
+			wg.Add(1)
+			go func(idx int, cert *x509.Certificate) {
+				defer wg.Done()
+				trustResults[idx].mozilla = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
+					Cert:          cert,
+					Roots:         input.MozillaPool,
+					Intermediates: intermediatePool,
+					TrustStore:    "mozilla",
+				})
+			}(i, rec.Cert)
 		}
+		wg.Wait()
+	}
+	if input.SystemPool != nil {
+		for i, rec := range certs {
+			if now.After(rec.NotAfter) || trustResults[i].mozilla {
+				continue
+			}
+			wg.Add(1)
+			go func(idx int, cert *x509.Certificate) {
+				defer wg.Done()
+				trustResults[idx].system = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
+					Cert:          cert,
+					Roots:         input.SystemPool,
+					Intermediates: intermediatePool,
+					TrustStore:    "system",
+				})
+			}(i, rec.Cert)
+		}
+		wg.Wait()
+	}
+
+	for i, rec := range certs {
+		expired := now.After(rec.NotAfter)
+		mozillaTrusted := trustResults[i].mozilla
+		systemTrusted := trustResults[i].system
 
 		switch rec.CertType {
 		case "root":

--- a/internal/certstore/memstore.go
+++ b/internal/certstore/memstore.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"log/slog"
 	"maps"
+	"runtime"
 	"slices"
 	"sort"
 	"sync"
@@ -428,13 +429,16 @@ func (s *MemStore) ScanSummary(input ScanSummaryInput) ScanSummary {
 		wg.Wait()
 	}
 	if input.SystemPool != nil {
+		sem := make(chan struct{}, runtime.NumCPU())
 		for i, rec := range certs {
 			if now.After(rec.NotAfter) || trustResults[i].mozilla {
 				continue
 			}
 			wg.Add(1)
+			sem <- struct{}{}
 			go func(idx int, cert *x509.Certificate) {
 				defer wg.Done()
+				defer func() { <-sem }()
 				trustResults[idx].system = certkit.VerifyChainTrust(certkit.VerifyChainTrustInput{
 					Cert:          cert,
 					Roots:         input.SystemPool,

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -293,28 +293,53 @@ func exportBundleCerts(ctx context.Context, input exportBundleCertsInput) error 
 			P12Password:   input.P12Password,
 			EncryptKey:    input.EncryptKey,
 		}
-		if err := certstore.ExportMatchedBundles(ctx, exportInput); err != nil {
-			// If mozilla verification failed, retry with system trust store
-			// so certificates trusted only by the host OS (e.g. corporate
-			// keychain roots) still export without requiring --force.
-			if input.Opts.Verify && isBundleVerificationError(err) && input.Opts.TrustStore != "system" {
-				slog.Debug("mozilla trust failed, retrying with system trust store", "cn", certRec.Cert.Subject.CommonName)
-				systemOpts := input.Opts
-				systemOpts.TrustStore = "system"
-				exportInput.BundleOpts = systemOpts
-				if retryErr := certstore.ExportMatchedBundles(ctx, exportInput); retryErr == nil {
-					continue
-				}
-			}
-			if input.Opts.Verify && isBundleVerificationError(err) {
-				delete(input.UsedFolders, folder)
-				slog.Debug("skipping untrusted bundle candidate", "cn", certRec.Cert.Subject.CommonName, "error", err)
-				continue
-			}
-			return fmt.Errorf("exporting bundle for %q: %w", certRec.Cert.Subject.CommonName, err)
+		skipped, err := exportMatchedBundleWithSystemFallback(ctx, certRec.Cert.Subject.CommonName, exportInput, input.Opts, certstore.ExportMatchedBundles)
+		if err != nil {
+			return err
+		}
+		if skipped {
+			delete(input.UsedFolders, folder)
+			continue
 		}
 	}
 	return nil
+}
+
+func exportMatchedBundleWithSystemFallback(
+	ctx context.Context,
+	commonName string,
+	exportInput certstore.ExportMatchedBundleInput,
+	opts certkit.BundleOptions,
+	exportFn func(context.Context, certstore.ExportMatchedBundleInput) error,
+) (bool, error) {
+	err := exportFn(ctx, exportInput)
+	if err == nil {
+		return false, nil
+	}
+
+	// If mozilla verification failed, retry with system trust store so
+	// certificates trusted only by the host OS (e.g. corporate keychain
+	// roots) still export without requiring --force.
+	if opts.Verify && isBundleVerificationError(err) && opts.TrustStore != "system" {
+		slog.Debug("mozilla trust failed, retrying with system trust store", "cn", commonName)
+		systemOpts := opts
+		systemOpts.TrustStore = "system"
+		exportInput.BundleOpts = systemOpts
+		retryErr := exportFn(ctx, exportInput)
+		if retryErr == nil {
+			return false, nil
+		}
+		if !isBundleVerificationError(retryErr) {
+			return false, fmt.Errorf("exporting bundle for %q: %w", commonName, retryErr)
+		}
+	}
+
+	if opts.Verify && isBundleVerificationError(err) {
+		slog.Debug("skipping untrusted bundle candidate", "cn", commonName, "error", err)
+		return true, nil
+	}
+
+	return false, fmt.Errorf("exporting bundle for %q: %w", commonName, err)
 }
 
 func isBundleVerificationError(err error) bool {

--- a/internal/exporter.go
+++ b/internal/exporter.go
@@ -283,7 +283,7 @@ func exportBundleCerts(ctx context.Context, input exportBundleCertsInput) error 
 		}
 		input.UsedFolders[folder] = input.BundleName
 
-		if err := certstore.ExportMatchedBundles(ctx, certstore.ExportMatchedBundleInput{
+		exportInput := certstore.ExportMatchedBundleInput{
 			Store:         input.Store,
 			SKIs:          []string{certRec.SKI},
 			BundleOpts:    input.Opts,
@@ -292,7 +292,20 @@ func exportBundleCerts(ctx context.Context, input exportBundleCertsInput) error 
 			RetryNoVerify: false,
 			P12Password:   input.P12Password,
 			EncryptKey:    input.EncryptKey,
-		}); err != nil {
+		}
+		if err := certstore.ExportMatchedBundles(ctx, exportInput); err != nil {
+			// If mozilla verification failed, retry with system trust store
+			// so certificates trusted only by the host OS (e.g. corporate
+			// keychain roots) still export without requiring --force.
+			if input.Opts.Verify && isBundleVerificationError(err) && input.Opts.TrustStore != "system" {
+				slog.Debug("mozilla trust failed, retrying with system trust store", "cn", certRec.Cert.Subject.CommonName)
+				systemOpts := input.Opts
+				systemOpts.TrustStore = "system"
+				exportInput.BundleOpts = systemOpts
+				if retryErr := certstore.ExportMatchedBundles(ctx, exportInput); retryErr == nil {
+					continue
+				}
+			}
 			if input.Opts.Verify && isBundleVerificationError(err) {
 				delete(input.UsedFolders, folder)
 				slog.Debug("skipping untrusted bundle candidate", "cn", certRec.Cert.Subject.CommonName, "error", err)

--- a/internal/exporter_test.go
+++ b/internal/exporter_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,7 +15,10 @@ import (
 	"github.com/sensiblebit/certkit/internal/certstore"
 )
 
-var errInjectedWriteFailure = errors.New("injected write failure")
+var (
+	errInjectedWriteFailure = errors.New("injected write failure")
+	errUnexpectedTrustStore = errors.New("unexpected trust store")
+)
 
 func TestExportBundles_EndToEnd(t *testing.T) {
 	// WHY: Integration test for the full export pipeline (store -> chain resolution -> file writing); verifies the bundle directory is created and populated.
@@ -399,6 +403,74 @@ func TestExportBundles_UntrustedBundleSkippedWithoutForce(t *testing.T) {
 	}
 	if len(entries) != 0 {
 		t.Fatalf("expected no exported bundles, got %d entries", len(entries))
+	}
+}
+
+func TestExportMatchedBundleWithSystemFallback_RetriesWithSystemTrust(t *testing.T) {
+	// WHY: Bundle export now defaults to Mozilla trust but should retry with the
+	// host system roots before classifying a candidate as untrusted.
+	t.Parallel()
+
+	var trustStores []string
+	exportFn := func(_ context.Context, input certstore.ExportMatchedBundleInput) error {
+		trustStores = append(trustStores, input.BundleOpts.TrustStore)
+		if input.BundleOpts.TrustStore == "mozilla" {
+			return fmt.Errorf("%w: mozilla verify failed", certkit.ErrChainVerificationFailed)
+		}
+		if input.BundleOpts.TrustStore == "system" {
+			return nil
+		}
+		return errUnexpectedTrustStore
+	}
+
+	skipped, err := exportMatchedBundleWithSystemFallback(
+		context.Background(),
+		"fallback.example.com",
+		certstore.ExportMatchedBundleInput{BundleOpts: certkit.BundleOptions{TrustStore: "mozilla", Verify: true}},
+		certkit.BundleOptions{TrustStore: "mozilla", Verify: true},
+		exportFn,
+	)
+	if err != nil {
+		t.Fatalf("exportMatchedBundleWithSystemFallback() error = %v, want nil", err)
+	}
+	if skipped {
+		t.Fatal("exportMatchedBundleWithSystemFallback() skipped = true, want false")
+	}
+	if got, want := strings.Join(trustStores, ","), "mozilla,system"; got != want {
+		t.Fatalf("trust store attempts = %q, want %q", got, want)
+	}
+}
+
+func TestExportMatchedBundleWithSystemFallback_ReturnsRetryFailure(t *testing.T) {
+	// WHY: If the system-trust retry reaches a real export failure, that error
+	// must be returned instead of being silently downgraded to an untrusted skip.
+	t.Parallel()
+
+	exportFn := func(_ context.Context, input certstore.ExportMatchedBundleInput) error {
+		if input.BundleOpts.TrustStore == "mozilla" {
+			return fmt.Errorf("%w: mozilla verify failed", certkit.ErrChainVerificationFailed)
+		}
+		if input.BundleOpts.TrustStore == "system" {
+			return errInjectedWriteFailure
+		}
+		return errUnexpectedTrustStore
+	}
+
+	skipped, err := exportMatchedBundleWithSystemFallback(
+		context.Background(),
+		"fallback.example.com",
+		certstore.ExportMatchedBundleInput{BundleOpts: certkit.BundleOptions{TrustStore: "mozilla", Verify: true}},
+		certkit.BundleOptions{TrustStore: "mozilla", Verify: true},
+		exportFn,
+	)
+	if skipped {
+		t.Fatal("exportMatchedBundleWithSystemFallback() skipped = true, want false")
+	}
+	if err == nil {
+		t.Fatal("exportMatchedBundleWithSystemFallback() error = nil, want non-nil")
+	}
+	if !errors.Is(err, errInjectedWriteFailure) {
+		t.Fatalf("error = %v, want injected retry failure", err)
 	}
 }
 

--- a/internal/verify.go
+++ b/internal/verify.go
@@ -492,6 +492,7 @@ func verifyCertAIAResolved(cert *x509.Certificate, allCerts []*x509.Certificate,
 			Cert:          cert,
 			Roots:         source.roots,
 			Intermediates: intermediates,
+			TrustStore:    source.name,
 		}) {
 			return true
 		}

--- a/internal/verify_test.go
+++ b/internal/verify_test.go
@@ -2055,10 +2055,10 @@ func TestVerifyCert_RevocationBehavior(t *testing.T) {
 			}
 			leaf := newRSALeaf(t, signer, "test.example.com", []string{"test.example.com"}, nil)
 
-			var ocspHits int32
+			var ocspHits atomic.Int32
 			if tc.ocspSigner != nil {
 				ocspServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					atomic.AddInt32(&ocspHits, 1)
+					ocspHits.Add(1)
 					resp := ocsp.Response{
 						Status:       ocsp.Good,
 						SerialNumber: leaf.cert.SerialNumber,
@@ -2080,10 +2080,10 @@ func TestVerifyCert_RevocationBehavior(t *testing.T) {
 				leaf.cert.OCSPServer = []string{strings.Replace(ocspServer.URL, "127.0.0.1", "localhost", 1)}
 			}
 
-			var crlHits int32
+			var crlHits atomic.Int32
 			if tc.crlSigner != nil {
 				crlServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-					atomic.AddInt32(&crlHits, 1)
+					crlHits.Add(1)
 					now := time.Now()
 					crlDER, err := x509.CreateRevocationList(rand.Reader, &x509.RevocationList{
 						Number:     big.NewInt(1),
@@ -2177,12 +2177,12 @@ func TestVerifyCert_RevocationBehavior(t *testing.T) {
 				t.Errorf("unexpected revoked error, got %v", result.Errors)
 			}
 			if tc.wantOCSPHits != nil {
-				if got := int(atomic.LoadInt32(&ocspHits)); got != *tc.wantOCSPHits {
+				if got := int(ocspHits.Load()); got != *tc.wantOCSPHits {
 					t.Errorf("OCSP endpoint hits = %d, want %d", got, *tc.wantOCSPHits)
 				}
 			}
 			if tc.wantCRLHits != nil {
-				if got := int(atomic.LoadInt32(&crlHits)); got != *tc.wantCRLHits {
+				if got := int(crlHits.Load()); got != *tc.wantCRLHits {
 					t.Errorf("CRL endpoint hits = %d, want %d", got, *tc.wantCRLHits)
 				}
 			}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -31,9 +31,9 @@
       }
     },
     "node_modules/@asamuzakjp/dom-selector": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.3.tgz",
-      "integrity": "sha512-Q6mU0Z6bfj6YvnX2k9n0JxiIwrCFN59x/nWmYQnAqP000ruX/yV+5bp/GRcF5T8ncvfwJQ7fgfP74DlpKExILA==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-7.0.4.tgz",
+      "integrity": "sha512-jXR6x4AcT3eIrS2fSNAwJpwirOkGcd+E7F7CP3zjdTqz9B/2huHOL8YJZBgekKwLML+u7qB/6P1LXQuMScsx0w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -215,9 +215,9 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.0.tgz",
-      "integrity": "sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
+      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -227,9 +227,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.0.tgz",
-      "integrity": "sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==",
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
+      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -290,20 +290,10 @@
         "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
-    "node_modules/@oxc-project/runtime": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/runtime/-/runtime-0.115.0.tgz",
-      "integrity": "sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
-    },
     "node_modules/@oxc-project/types": {
-      "version": "0.115.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.115.0.tgz",
-      "integrity": "sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==",
+      "version": "0.122.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
+      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -311,9 +301,9 @@
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-SJ+/g+xNnOh6NqYxD0V3uVN4W3VfnrGsC9/hoglicgTNfABFG9JjISvkkU0dNY84MNHLWyOgxP9v9Y9pX4S7+A==",
       "cpu": [
         "arm64"
       ],
@@ -328,9 +318,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-7WQgR8SfOPwmDZGFkThUvsmd/nwAWv91oCO4I5LS7RKrssPZmOt7jONN0cW17ydGC1n/+puol1IpoieKqQidmg==",
       "cpu": [
         "arm64"
       ],
@@ -345,9 +335,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-39Ks6UvIHq4rEogIfQBoBRusj0Q0nPVWIvqmwBLaT6aqQGIakHdESBVOPRRLacy4WwUPIx4ZKzfZ9PMW+IeyUQ==",
       "cpu": [
         "x64"
       ],
@@ -362,9 +352,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfsm0ZHfhiqrvWjJAmzsqiIFPz5e7mAoCOPBNTcNgkiid/LaFKiq92+0ojH+nmJmKYkre4t71BWXUZDNp7vsag==",
       "cpu": [
         "x64"
       ],
@@ -379,9 +369,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.9.tgz",
-      "integrity": "sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.11.tgz",
+      "integrity": "sha512-zjQaUtSyq1nVe3nxmlSCuR96T1LPlpvmJ0SZy0WJFEsV4kFbXcq2u68L4E6O0XeFj4aex9bEauqjW8UQBeAvfQ==",
       "cpu": [
         "arm"
       ],
@@ -396,9 +386,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-WMW1yE6IOnehTcFE9eipFkm3XN63zypWlrJQ2iF7NrQ9b2LDRjumFoOGJE8RJJTJCTBAdmLMnJ8uVitACUUo1Q==",
       "cpu": [
         "arm64"
       ],
@@ -416,9 +406,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-jfndI9tsfm4APzjNt6QdBkYwre5lRPUgHeDHoI7ydKUuJvz3lZeCfMsI56BZj+7BYqiKsJm7cfd/6KYV7ubrBg==",
       "cpu": [
         "arm64"
       ],
@@ -436,9 +426,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-ZlFgw46NOAGMgcdvdYwAGu2Q+SLFA9LzbJLW+iyMOJyhj5wk6P3KEE9Gct4xWwSzFoPI7JCdYmYMzVtlgQ+zfw==",
       "cpu": [
         "ppc64"
       ],
@@ -456,9 +446,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-hIOYmuT6ofM4K04XAZd3OzMySEO4K0/nc9+jmNcxNAxRi6c5UWpqfw3KMFV4MVFWL+jQsSh+bGw2VqmaPMTLyw==",
       "cpu": [
         "s390x"
       ],
@@ -476,9 +466,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.9.tgz",
-      "integrity": "sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.11.tgz",
+      "integrity": "sha512-qXBQQO9OvkjjQPLdUVr7Nr2t3QTZI7s4KZtfw7HzBgjbmAPSFwSv4rmET9lLSgq3rH/ndA3ngv3Qb8l2njoPNA==",
       "cpu": [
         "x64"
       ],
@@ -496,9 +486,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.9.tgz",
-      "integrity": "sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.11.tgz",
+      "integrity": "sha512-/tpFfoSTzUkH9LPY+cYbqZBDyyX62w5fICq9qzsHLL8uTI6BHip3Q9Uzft0wylk/i8OOwKik8OxW+QAhDmzwmg==",
       "cpu": [
         "x64"
       ],
@@ -516,9 +506,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.9.tgz",
-      "integrity": "sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.11.tgz",
+      "integrity": "sha512-mcp3Rio2w72IvdZG0oQ4bM2c2oumtwHfUfKncUM6zGgz0KgPz4YmDPQfnXEiY5t3+KD/i8HG2rOB/LxdmieK2g==",
       "cpu": [
         "arm64"
       ],
@@ -533,9 +523,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.9.tgz",
-      "integrity": "sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LXk5Hii1Ph9asuGRjBuz8TUxdc1lWzB7nyfdoRgI0WGPZKmCxvlKk8KfYysqtr4MfGElu/f/pEQRh8fcEgkrWw==",
       "cpu": [
         "wasm32"
       ],
@@ -550,9 +540,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-dDwf5otnx0XgRY1yqxOC4ITizcdzS/8cQ3goOWv3jFAo4F+xQYni+hnMuO6+LssHHdJW7+OCVL3CoU4ycnh35Q==",
       "cpu": [
         "arm64"
       ],
@@ -567,9 +557,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.9.tgz",
-      "integrity": "sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.11.tgz",
+      "integrity": "sha512-LN4/skhSggybX71ews7dAj6r2geaMJfm3kMbK2KhFMg9B10AZXnKoLCVVgzhMHL0S+aKtr4p8QbAW8k+w95bAA==",
       "cpu": [
         "x64"
       ],
@@ -584,9 +574,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.9.tgz",
-      "integrity": "sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.11.tgz",
+      "integrity": "sha512-xQO9vbwBecJRv9EUcQ/y0dzSTJgA7Q6UVN7xp6B81+tBGSLVAK03yJ9NkJaUA7JFD91kbjxRSC/mDnmvXzbHoQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -634,16 +624,16 @@
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.0.tgz",
-      "integrity": "sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
+      "integrity": "sha512-xAV0fqBTk44Rn6SjJReEQkHP3RrqbJo6JQ4zZ7/uVOiJZRarBtblzrOfFIZeYUrukp2YD6snZG6IBqhOoHTm+A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "chai": "^6.2.2",
         "tinyrainbow": "^3.0.3"
       },
@@ -652,13 +642,13 @@
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.0.tgz",
-      "integrity": "sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.1.tgz",
+      "integrity": "sha512-h3BOylsfsCLPeceuCPAAJ+BvNwSENgJa4hXoXu4im0bs9Lyp4URc4JYK4pWLZ4pG/UQn7AT92K6IByi6rE6g3A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "4.1.0",
+        "@vitest/spy": "4.1.1",
         "estree-walker": "^3.0.3",
         "magic-string": "^0.30.21"
       },
@@ -667,7 +657,7 @@
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -679,9 +669,9 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.0.tgz",
-      "integrity": "sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.1.tgz",
+      "integrity": "sha512-GM+TEQN5WhOygr1lp7skeVjdLPqqWMHsfzXrcHAqZJi/lIVh63H0kaRCY8MDhNWikx19zBUK8ceaLB7X5AH9NQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -692,13 +682,13 @@
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.0.tgz",
-      "integrity": "sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.1.tgz",
+      "integrity": "sha512-f7+FPy75vN91QGWsITueq0gedwUZy1fLtHOCMeQpjs8jTekAHeKP80zfDEnhrleviLHzVSDXIWuCIOFn3D3f8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "4.1.0",
+        "@vitest/utils": "4.1.1",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -706,14 +696,14 @@
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.0.tgz",
-      "integrity": "sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.1.tgz",
+      "integrity": "sha512-kMVSgcegWV2FibXEx9p9WIKgje58lcTbXgnJixfcg15iK8nzCXhmalL0ZLtTWLW9PH1+1NEDShiFFedB3tEgWg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
@@ -722,9 +712,9 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.0.tgz",
-      "integrity": "sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.1.tgz",
+      "integrity": "sha512-6Ti/KT5OVaiupdIZEuZN7l3CZcR0cxnxt70Z0//3CtwgObwA6jZhmVBA3yrXSVN3gmwjgd7oDNLlsXz526gpRA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -732,13 +722,13 @@
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.0.tgz",
-      "integrity": "sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.1.tgz",
+      "integrity": "sha512-cNxAlaB3sHoCdL6pj6yyUXv9Gry1NHNg0kFTXdvSIZXLHsqKH7chiWOkwJ5s5+d/oMwcoG9T0bKU38JZWKusrQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "4.1.0",
+        "@vitest/pretty-format": "4.1.1",
         "convert-source-map": "^2.0.0",
         "tinyrainbow": "^3.0.3"
       },
@@ -922,14 +912,14 @@
       "license": "MIT"
     },
     "node_modules/jsdom": {
-      "version": "29.0.0",
-      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.0.tgz",
-      "integrity": "sha512-9FshNB6OepopZ08unmmGpsF7/qCjxGPbo3NbgfJAnPeHXnsODE9WWffXZtRFRFe0ntzaAOcSKNJFz8wiyvF1jQ==",
+      "version": "29.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-29.0.1.tgz",
+      "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
-        "@asamuzakjp/dom-selector": "^7.0.2",
+        "@asamuzakjp/dom-selector": "^7.0.3",
         "@bramus/specificity": "^2.4.2",
         "@csstools/css-syntax-patches-for-csstree": "^1.1.1",
         "@exodus/bytes": "^1.15.0",
@@ -943,7 +933,7 @@
         "saxes": "^6.0.0",
         "symbol-tree": "^3.2.4",
         "tough-cookie": "^6.0.1",
-        "undici": "^7.24.3",
+        "undici": "^7.24.5",
         "w3c-xmlserializer": "^5.0.0",
         "webidl-conversions": "^8.0.1",
         "whatwg-mimetype": "^5.0.0",
@@ -1320,9 +1310,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1382,14 +1372,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.9",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.9.tgz",
-      "integrity": "sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==",
+      "version": "1.0.0-rc.11",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.11.tgz",
+      "integrity": "sha512-NRjoKMusSjfRbSYiH3VSumlkgFe7kYAa3pzVOsVYVFY3zb5d7nS+a3KGQ7hJKXuYWbzJKPVQ9Wxq2UvyK+ENpw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.115.0",
-        "@rolldown/pluginutils": "1.0.0-rc.9"
+        "@oxc-project/types": "=0.122.0",
+        "@rolldown/pluginutils": "1.0.0-rc.11"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -1398,21 +1388,21 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.9",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.9",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.9",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.9",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.9",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.9",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.9"
+        "@rolldown/binding-android-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-darwin-x64": "1.0.0-rc.11",
+        "@rolldown/binding-freebsd-x64": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.11",
+        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.11",
+        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.11",
+        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.11",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.11",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.11"
       }
     },
     "node_modules/saxes": {
@@ -1511,22 +1501,22 @@
       }
     },
     "node_modules/tldts": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.26.tgz",
-      "integrity": "sha512-WiGwQjr0qYdNNG8KpMKlSvpxz652lqa3Rd+/hSaDcY4Uo6SKWZq2LAF+hsAhUewTtYhXlorBKgNF3Kk8hnjGoQ==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.27.tgz",
+      "integrity": "sha512-I4FZcVFcqCRuT0ph6dCDpPuO4Xgzvh+spkcTr1gK7peIvxWauoloVO0vuy1FQnijT63ss6AsHB6+OIM4aXHbPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tldts-core": "^7.0.26"
+        "tldts-core": "^7.0.27"
       },
       "bin": {
         "tldts": "bin/cli.js"
       }
     },
     "node_modules/tldts-core": {
-      "version": "7.0.26",
-      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.26.tgz",
-      "integrity": "sha512-5WJ2SqFsv4G2Dwi7ZFVRnz6b2H1od39QME1lc2y5Ew3eWiZMAeqOAfWpRP9jHvhUl881406QtZTODvjttJs+ew==",
+      "version": "7.0.27",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.27.tgz",
+      "integrity": "sha512-YQ7uPjgWUibIK6DW5lrKujGwUKhLevU4hcGbP5O6TcIUb+oTjJYJVWPS4nZsIHrEEEG6myk/oqAJUEQmpZrHsg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1565,9 +1555,9 @@
       "optional": true
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.5.tgz",
+      "integrity": "sha512-3IWdCpjgxp15CbJnsi/Y9TCDE7HWVN19j1hmzVhoAkY/+CJx449tVxT5wZc1Gwg8J+P0LWvzlBzxYRnHJ+1i7Q==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1575,17 +1565,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.0.tgz",
-      "integrity": "sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==",
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.2.tgz",
+      "integrity": "sha512-1gFhNi+bHhRE/qKZOJXACm6tX4bA3Isy9KuKF15AgSRuRazNBOJfdDemPBU16/mpMxApDPrWvZ08DcLPEoRnuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/runtime": "0.115.0",
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.3",
         "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.9",
+        "rolldown": "1.0.0-rc.11",
         "tinyglobby": "^0.2.15"
       },
       "bin": {
@@ -1602,7 +1591,7 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.0.0-alpha.31",
+        "@vitejs/devtools": "^0.1.0",
         "esbuild": "^0.27.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
@@ -1654,19 +1643,19 @@
       }
     },
     "node_modules/vitest": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.0.tgz",
-      "integrity": "sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.1.tgz",
+      "integrity": "sha512-yF+o4POL41rpAzj5KVILUxm1GCjKnELvaqmU9TLLUbMfDzuN0UpUR9uaDs+mCtjPe+uYPksXDRLQGGPvj1cTmA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/expect": "4.1.0",
-        "@vitest/mocker": "4.1.0",
-        "@vitest/pretty-format": "4.1.0",
-        "@vitest/runner": "4.1.0",
-        "@vitest/snapshot": "4.1.0",
-        "@vitest/spy": "4.1.0",
-        "@vitest/utils": "4.1.0",
+        "@vitest/expect": "4.1.1",
+        "@vitest/mocker": "4.1.1",
+        "@vitest/pretty-format": "4.1.1",
+        "@vitest/runner": "4.1.1",
+        "@vitest/snapshot": "4.1.1",
+        "@vitest/spy": "4.1.1",
+        "@vitest/utils": "4.1.1",
         "es-module-lexer": "^2.0.0",
         "expect-type": "^1.3.0",
         "magic-string": "^0.30.21",
@@ -1678,7 +1667,7 @@
         "tinyexec": "^1.0.2",
         "tinyglobby": "^0.2.15",
         "tinyrainbow": "^3.0.3",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
@@ -1694,13 +1683,13 @@
         "@edge-runtime/vm": "*",
         "@opentelemetry/api": "^1.9.0",
         "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
-        "@vitest/browser-playwright": "4.1.0",
-        "@vitest/browser-preview": "4.1.0",
-        "@vitest/browser-webdriverio": "4.1.0",
-        "@vitest/ui": "4.1.0",
+        "@vitest/browser-playwright": "4.1.1",
+        "@vitest/browser-preview": "4.1.1",
+        "@vitest/browser-webdriverio": "4.1.1",
+        "@vitest/ui": "4.1.1",
         "happy-dom": "*",
         "jsdom": "*",
-        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {


### PR DESCRIPTION
## Summary

- **Breaking:** Default `TrustStore` in `DefaultOptions()` changed from `"system"` to `"mozilla"` — eliminates multi-minute hangs on macOS when scanning large certificate stores
- Parallelize trust verification across scan summary, `--dump-certs`, and AIA resolution using goroutines
- Add `TrustStore` label to `VerifyChainTrustInput` with debug logging for every trust check

## The Bug

On macOS, `x509.Certificate.Verify` with the system cert pool calls into the Security framework's `SecTrustEvaluateWithError` — a **blocking syscall** that performs OCSP/CRL network checks and can take seconds per certificate. The scan command was verifying every certificate **sequentially** against the system trust store:

```
goroutine 1 [syscall]:
  crypto/x509/internal/macos.SecTrustEvaluateWithError
  crypto/x509.(*Certificate).systemVerify
  certkit.VerifyChainTrust
  certkit.countAIAUnresolvedIssuers       ← called per-bundle during export
  certkit.Bundle
  certstore.ExportMatchedBundles
  internal.ExportBundles
  main.runScan
```

With ~2500 certificates and ~134,000 AIA resolution trust checks, the scan would hang indefinitely (killed after 10+ minutes with zero output).

## Root Cause

Two compounding issues:

1. **`DefaultOptions()` used `TrustStore: "system"`** — every `Bundle()` call during export verified certs against macOS SecTrust, which does network I/O per cert
2. **All trust checks were sequential** — no parallelism in `ScanSummary`, `countAIAUnresolvedIssuers`, or `--dump-certs`

## The Fix

### 1. Default to Mozilla (pure Go, no syscalls)

The embedded Mozilla root pool uses Go's `x509.Verify` with an in-memory cert pool — no system calls, no network I/O. This alone eliminates the hang.

```go
// Before
TrustStore: "system"  // macOS SecTrustEvaluateWithError per cert

// After
TrustStore: "mozilla"  // pure Go x509.Verify — fast
```

### 2. Mozilla-first short-circuit

System trust checks now only run for certs that Mozilla didn't trust. Since most valid certs are Mozilla-trusted, this skips the expensive syscall for the majority:

```
Before: 134,000 system trust checks (all blocking syscalls)
After:    2,208 system trust checks (only mozilla-untrusted certs)
```

### 3. Parallel verification

All trust checks within a phase fire concurrently via goroutines:
- Mozilla checks all run in parallel (pure Go, safe to fan out aggressively)
- System checks run in parallel only for the mozilla-untrusted remainder

### 4. Debug observability

Every `VerifyChainTrust` call now logs subject, store name, and result at debug level:

```
level=DEBUG msg="verifying chain trust" subject=example.com store=mozilla
level=DEBUG msg="chain trust result" subject=example.com store=mozilla trusted=true
```

## Results

| Metric | Before | After |
|--------|--------|-------|
| Scan time (~2500 certs) | **hung indefinitely** | **~45 seconds** |
| System trust calls | ~134,000 | 2,208 |
| Mozilla trust calls | 0 | 2,722 |
| AIA resolve calls | ~134,000 (system) | ~134,000 (mozilla, pure Go) |

## Breaking Change

`DefaultOptions().TrustStore` is now `"mozilla"` instead of `"system"`. Library callers that relied on the system trust store as default should explicitly set `opts.TrustStore = "system"`.

## Test plan

- [x] All existing tests pass (`pre-commit run --all-files`)
- [x] `DefaultOptions()` test updated for new default
- [x] Manual test: `certkit scan <dir> --bundle-path <out> -l debug` completes in ~45s with correct output
- [x] Debug logs confirm mozilla-first short-circuit (zero system calls when all certs are mozilla-trusted)

🤖 Generated with [Claude Code](https://claude.com/claude-code)